### PR TITLE
Refactor: Simplify validation for description and steps fields and fixed regex of thumbnail field (#47)

### DIFF
--- a/src/shared/components/forms/RecipeForm/sections/BasicInfoSection.tsx
+++ b/src/shared/components/forms/RecipeForm/sections/BasicInfoSection.tsx
@@ -33,10 +33,6 @@ const BasicInfoSection = ({ register, errors }: BasicInfoSectionProps) => {
         <Textarea
           {...register("description", {
             required: "La descripción es requerida",
-            minLength: {
-              value: 10,
-              message: "La descripción debe tener al menos 10 caracteres",
-            },
           })}
           size="sm"
           resize="none"
@@ -52,8 +48,8 @@ const BasicInfoSection = ({ register, errors }: BasicInfoSectionProps) => {
           {...register("thumbnail", {
             pattern: {
               value:
-                /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/,
-              message: "Ingresa una URL válida",
+                /^https?:\/\/[^\s]+$/,
+              message: "Ingresa una URL válida que comience con http:// o https://",
             },
           })}
           placeholder="https://ejemplo.com/imagen.jpg"

--- a/src/shared/components/forms/RecipeForm/sections/StepsSection.tsx
+++ b/src/shared/components/forms/RecipeForm/sections/StepsSection.tsx
@@ -9,16 +9,10 @@ import { StepsSectionProps } from "../types";
 
 const StepsSection = ({ register, errors }: StepsSectionProps) => {
   return (
-    <FormControl isRequired isInvalid={!!errors?.steps}>
+    <FormControl isInvalid={!!errors?.steps}>
       <FormLabel>Pasos</FormLabel>
       <Textarea
-        {...register("steps", {
-          required: "Los pasos son requeridos",
-          minLength: {
-            value: 10,
-            message: "Los pasos deben tener al menos 10 caracteres",
-          },
-        })}
+        {...register("steps")}
         rows={7}
         size="sm"
         resize="none"


### PR DESCRIPTION
### 📋 Resumen

- Corrección del regex de URL para thumbnails - ahora acepta URLs con caracteres especiales y query parameters
- Campo de descripción de pasos convertido a opcional 
- Eliminación de restricción de 10 caracteres mínimo en descripciones
- Mejora general en la flexibilidad del formulario

---

### 🧩 Tipo de cambio

- [ ] ✨ Feature (nueva funcionalidad)
- [X] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #47
- Issue: #48 

---

### 🗒️ Notas adicionales

**🔧 Detalles técnicos:**
- **Regex anterior**: `/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/`
- **Regex nuevo**: `/^https?:\/\/[^\s]+$/`

---