### PR TITLE
Feature: Button and view for duplicate `Recipe` (#52)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,5 @@ Descripción
 ### 🗒️ Notas adicionales
 
 Sin detalles importantes que mencionar
+
+---

--- a/src/features/recipe-book/components/Card.tsx
+++ b/src/features/recipe-book/components/Card.tsx
@@ -7,18 +7,13 @@ import {
   Flex,
   Heading,
   HStack,
-  Tag,
-  TagLabel,
-  TagRightIcon,
   Text,
 } from "@chakra-ui/react";
-import { FaClock, FaStar, FaUsers } from "react-icons/fa";
 import { FaKitchenSet } from "react-icons/fa6";
 
 import { Recipe } from "../types";
-import { RecipeCardImage } from "../../../shared/components/ui";
-
-import { setTimeText } from "../utils/setTimeText";
+import { RecipeCardImage, RecipeTags } from "../../../shared/components/ui";
+import { useRecipeTags } from "../../../shared/components/ui/RecipeTags/useRecipeTags";
 
 type Props = {
   recipe: Recipe;
@@ -26,6 +21,14 @@ type Props = {
 
 function RecipeCard({ recipe }: Props) {
   const navigate = useNavigate();
+  const allTags = useRecipeTags(recipe);
+
+  // Filtrar solo los tags que queremos mostrar: score, time, servings
+  const cardTags = allTags.filter((_, index) => {
+    // Basado en el orden del hook: [score, category, origin, time, servings]
+    // Queremos: score (0), time (3), servings (4)
+    return index === 0 || index === 3 || index === 4;
+  });
 
   return (
     <Card p={2} userSelect="none">
@@ -50,26 +53,7 @@ function RecipeCard({ recipe }: Props) {
             </HStack>
           </Button>
 
-          <HStack>
-            <Tag h={10} variant="solid" bgColor="gray.500">
-              <TagLabel ml={1} fontSize={16}>
-                {setTimeText(recipe.time)}
-              </TagLabel>
-              <TagRightIcon mr={1} boxSize="18px" as={FaClock} />
-            </Tag>
-            <Tag h={10} variant="solid" bgColor="gray.500">
-              <TagLabel ml={1} fontSize={20}>
-                {recipe.servings}
-              </TagLabel>
-              <TagRightIcon mr={1} boxSize="20px" as={FaUsers} />
-            </Tag>
-            <Tag h={10} variant="solid" bgColor="yellow.500">
-              <TagLabel ml={1} fontSize={20}>
-                {recipe.score}
-              </TagLabel>
-              <TagRightIcon mr={1} boxSize="18px" as={FaStar} />
-            </Tag>
-          </HStack>
+          <RecipeTags tags={cardTags} size="md" />
         </Flex>
       </CardFooter>
     </Card>

--- a/src/features/recipe-book/components/Modal.tsx
+++ b/src/features/recipe-book/components/Modal.tsx
@@ -10,12 +10,13 @@ import {
   useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
-import { FaPencilAlt, FaThumbtack, FaTrash } from "react-icons/fa";
+import { FaCopy, FaPencilAlt, FaThumbtack, FaTrash } from "react-icons/fa";
 
 import RecipeModalSkeleton from "./ModalSkeleton";
 import RecipeModalContent from "./ModalContent";
 import ConfirmationDeleteModal from "./DeleteModal";
 
+import { useRecipeDuplicate } from "../hooks";
 import { Recipe } from "../types";
 
 type Props = {
@@ -27,6 +28,7 @@ type Props = {
 
 function RecipeModal({ isOpen, onClose, loading, data }: Props) {
   const navigate = useNavigate();
+  const { duplicateRecipe, isLoading: isDuplicating } = useRecipeDuplicate();
 
   const {
     isOpen: isOpenDeleteConfirmation,
@@ -35,6 +37,13 @@ function RecipeModal({ isOpen, onClose, loading, data }: Props) {
   } = useDisclosure();
 
   const [isUnlocked, setIsUnlocked] = useState(true);
+
+  const handleDuplicate = async () => {
+    if (data) {
+      await duplicateRecipe(data.id, data.name);
+      onClose();
+    }
+  };
 
   const handleEdit = () => {
     navigate(`/recipes/update/${data?.id}`);
@@ -69,6 +78,16 @@ function RecipeModal({ isOpen, onClose, loading, data }: Props) {
             <Spacer />
 
             <Button
+              isDisabled={!isUnlocked || isDuplicating}
+              variant="copyButton"
+              onClick={handleDuplicate}
+              isLoading={isDuplicating}
+            >
+              <FaCopy color={useColorModeValue("#1A202C", "white")} />
+            </Button>
+
+            <Button
+              ml={4}
               isDisabled={!isUnlocked}
               variant="editButton"
               onClick={handleEdit}

--- a/src/features/recipe-book/hooks/index.ts
+++ b/src/features/recipe-book/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useRecipeFilters } from "./useRecipeFilters";
+export { useRecipeDuplicate } from "./useRecipeDuplicate";

--- a/src/features/recipe-book/hooks/useRecipeDuplicate.ts
+++ b/src/features/recipe-book/hooks/useRecipeDuplicate.ts
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useToast } from "@chakra-ui/react";
+
+import { API_BASE_URL, API_KEY } from "../../../shared/constants/environment";
+
+export interface DuplicateRecipeResponse {
+  idCategory: number;
+  idOrigin: number;
+  name: string;
+  description: string;
+  thumbnail?: string;
+  score: number;
+  time: number;
+  servings: number;
+  ingredients: Array<{
+    id: number;
+    name: string;
+    unit: string;
+    quantity: number;
+  }>;
+  steps: Array<{
+    number: number;
+    instruction: string;
+  }>;
+}
+
+export const useRecipeDuplicate = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  const duplicateRecipe = async (recipeId: number, recipeName: string) => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/recipe/${recipeId}/duplicate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "api-key": API_KEY,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Error al duplicar la receta");
+      }
+
+      const { data } = await response.json();
+
+      toast({
+        position: "top",
+        title: "Receta duplicada",
+        description: `"${recipeName}" se ha duplicado exitosamente. Ahora puedes editarla.`,
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+
+      navigate("/recipes/create", {
+        state: {
+          duplicatedData: data,
+          originalName: recipeName,
+          isDuplicate: true,
+        },
+      });
+    } catch (error) {
+      console.error("Error duplicating recipe:", error);
+
+      toast({
+        position: "top",
+        title: "Error al duplicar",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Por favor intente nuevamente.",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    duplicateRecipe,
+    isLoading,
+  };
+};

--- a/src/features/recipe-book/pages/Create.tsx
+++ b/src/features/recipe-book/pages/Create.tsx
@@ -1,5 +1,6 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { Box, Heading, Flex, useToast } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 
 import {
   RecipeForm,
@@ -12,63 +13,95 @@ import {
   RecipeFormSubmissionData,
   IngredientFormData,
 } from "../../../shared/components/forms/RecipeForm/types";
+import { Recipe } from "../types";
 
 const CreateRecipePage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const toast = useToast();
   const { axiosFetch } = useAxios();
 
+  const [initialData, setInitialData] = useState<Recipe | null>(null);
+  const [pageTitle, setPageTitle] = useState("Crear nueva Receta");
+
+  useEffect(() => {
+    if (location.state?.duplicatedData && location.state?.isDuplicate) {
+      const { duplicatedData, originalName } = location.state;
+
+      // Convertir 'DuplicateRecipeResponse' a Recipe format
+      const recipeData: Recipe = {
+        id: 0, // Temporal, será asignado al guardar
+        idCategory: duplicatedData.idCategory,
+        idOrigin: duplicatedData.idOrigin,
+        name: duplicatedData.name,
+        description: duplicatedData.description,
+        thumbnail: duplicatedData.thumbnail || "",
+        score: duplicatedData.score,
+        time: duplicatedData.time,
+        servings: duplicatedData.servings,
+        createdAt: "",
+        updatedAt: "",
+        category: {
+          id: duplicatedData.idCategory,
+          name: "",
+          createdAt: "",
+          updatedAt: "",
+        },
+        origin: {
+          id: duplicatedData.idOrigin,
+          name: "",
+          createdAt: "",
+          updatedAt: "",
+        },
+        ingredients: duplicatedData.ingredients.map((ing: any) => ({
+          quantity: ing.quantity,
+          ingredient: {
+            id: ing.id.toString(),
+            name: ing.name,
+            unit: ing.unit,
+          },
+          id: 0,
+          idRecipe: 0,
+        })),
+        steps: duplicatedData.steps.map((step: any) => ({
+          id: 0,
+          number: step.number,
+          instruction: step.instruction,
+          idRecipe: 0,
+        })),
+      };
+
+      setInitialData(recipeData);
+      setPageTitle(`Editando copia de "${originalName}"`);
+    }
+  }, [location.state]);
+
   const handleSubmit = async (data: RecipeFormSubmissionData) => {
     try {
-      // Validar que se hayan seleccionado categoría y origen
+      // Validar que se hayan seleccionado "categoría" y "origen",
+      // y que los ingredientes sean válidos
+      let messageError = "";
+
       if (!data.selectedCategory || data.selectedCategory.id === 0) {
-        toast({
-          position: "top",
-          title: "Error",
-          description: "Por favor selecciona una categoría",
-          status: "error",
-          duration: 3000,
-          isClosable: true,
-        });
-        return;
+        messageError = "Por favor selecciona una categoría";
+      } else if (!data.selectedOrigin || data.selectedOrigin.id === 0) {
+        messageError = "Por favor selecciona un origen";
+      } else if (!data.ingredients || data.ingredients.length === 0) {
+        messageError = "Por favor agrega al menos un ingrediente";
+      } else if (
+        data.ingredients.some(
+          (ingredient: IngredientFormData) =>
+            ingredient.id === "0" || !ingredient.quantity.trim()
+        )
+      ) {
+        messageError = "Por favor completa todos los ingredientes";
       }
 
-      if (!data.selectedOrigin || data.selectedOrigin.id === 0) {
+      if (messageError) {
         toast({
           position: "top",
           title: "Error",
-          description: "Por favor selecciona un origen",
-          status: "error",
-          duration: 3000,
-          isClosable: true,
-        });
-        return;
-      }
-
-      // Validar ingredientes
-      if (!data.ingredients || data.ingredients.length === 0) {
-        toast({
-          position: "top",
-          title: "Error",
-          description: "Por favor agrega al menos un ingrediente",
-          status: "error",
-          duration: 3000,
-          isClosable: true,
-        });
-        return;
-      }
-
-      // Validar que todos los ingredientes tengan datos válidos
-      const invalidIngredients = data.ingredients.filter(
-        (ingredient: IngredientFormData) =>
-          ingredient.id === "0" || !ingredient.quantity.trim()
-      );
-
-      if (invalidIngredients.length > 0) {
-        toast({
-          position: "top",
-          title: "Error",
-          description: "Por favor completa todos los ingredientes",
+          description: messageError,
           status: "error",
           duration: 3000,
           isClosable: true,
@@ -99,10 +132,14 @@ const CreateRecipePage = () => {
 
       toast({
         position: "top",
-        title: "Receta creada",
-        description: `La receta "${data.name}" ha sido creada exitosamente`,
+        title: location.state?.isDuplicate
+          ? "Receta duplicada guardada"
+          : "Receta creada",
+        description: location.state?.isDuplicate
+          ? `La copia de "${location.state.originalName}" ha sido guardada exitosamente como "${data.name}"`
+          : `La receta "${data.name}" ha sido creada exitosamente`,
         status: "success",
-        duration: 3000,
+        duration: location.state?.isDuplicate ? 5000 : 3000,
         isClosable: true,
       });
 
@@ -111,8 +148,7 @@ const CreateRecipePage = () => {
       toast({
         position: "top",
         title: "Error al crear receta",
-        description:
-          "No se pudo crear la receta. Por favor intente nuevamente.",
+        description: "Por favor intente nuevamente.",
         status: "error",
         duration: 3000,
         isClosable: true,
@@ -125,13 +161,18 @@ const CreateRecipePage = () => {
   return (
     <Box>
       <Flex justify="space-between" align="center" mb={6}>
-        <Heading size="lg">Crear nueva Receta</Heading>
+        <Heading size="lg">{pageTitle}</Heading>
         <RecipeFormButtons
-          submitButtonText="Guardar Receta"
+          submitButtonText={
+            location.state?.isDuplicate ? "Guardar Copia" : "Guardar Receta"
+          }
           cancelAction={() => navigate("/recipes")}
         />
       </Flex>
-      <RecipeForm onSubmit={handleSubmit} />
+      <RecipeForm
+        onSubmit={handleSubmit}
+        initialData={initialData || undefined}
+      />
     </Box>
   );
 };

--- a/src/shared/components/forms/RecipeForm/useRecipeForm.ts
+++ b/src/shared/components/forms/RecipeForm/useRecipeForm.ts
@@ -102,6 +102,24 @@ export const useRecipeForm = (initialData?: Recipe) => {
     }
   }, [initialData, setValue]);
 
+  useEffect(() => {
+    if (initialData && categories.length > 0 && origins.length > 0) {
+      const foundCategory = categories.find(
+        (category) => category.id === initialData.idCategory
+      );
+      if (foundCategory) {
+        setSelectedCategory(foundCategory);
+      }
+
+      const foundOrigin = origins.find(
+        (origin) => origin.id === initialData.idOrigin
+      );
+      if (foundOrigin) {
+        setSelectedOrigin(foundOrigin);
+      }
+    }
+  }, [initialData, categories, origins]);
+
   // Función para resetear el formulario
   const resetForm = () => {
     reset();

--- a/src/shared/components/ui/RecipeTags/RecipeTags.tsx
+++ b/src/shared/components/ui/RecipeTags/RecipeTags.tsx
@@ -2,7 +2,7 @@ import {
   HStack,
   Tag,
   TagLabel,
-  TagRightIcon,
+  TagLeftIcon,
   Wrap,
   WrapItem,
   BoxProps,
@@ -18,8 +18,10 @@ const RecipeTags = ({
 }: RecipeTagsProps & BoxProps) => {
   const renderTag = (tag: TagData, index: number) => (
     <Tag key={index} colorScheme={tag.colorScheme || "gray"} size={size}>
-      <TagLabel>{tag.label}</TagLabel>
-      <TagRightIcon mr={1} boxSize={tag.iconSize || "16px"} as={tag.icon} />
+      <TagLeftIcon boxSize={tag.iconSize || "16px"} as={tag.icon} />
+      <TagLabel mr="2px" my="5px">
+        {tag.label}
+      </TagLabel>
     </Tag>
   );
 

--- a/src/shared/components/ui/RecipeTags/useRecipeTags.ts
+++ b/src/shared/components/ui/RecipeTags/useRecipeTags.ts
@@ -14,7 +14,10 @@ export const useRecipeTags = (recipe: Recipe): TagData[] => {
 
   return [
     {
-      label: recipe.score.toString(),
+      label:
+        recipe.score.toString() === "0"
+          ? "Sin calificar"
+          : recipe.score.toString(),
       icon: FaStar,
       colorScheme: "yellow",
       iconSize: "16px",

--- a/src/shared/themes/button.ts
+++ b/src/shared/themes/button.ts
@@ -101,6 +101,20 @@ const ButtonTheme = {
         },
       },
     },
+    copyButton: {
+      backgroundColor: "gray.300",
+      color: "white",
+      ":hover": {
+        backgroundColor: "purple.500",
+      },
+      _dark: {
+        backgroundColor: "#3C4658",
+        color: "white",
+        ":hover": {
+          backgroundColor: "purple.500",
+        },
+      },
+    },
   },
 };
 


### PR DESCRIPTION
### 📋 Resumen

- Se implementó una funcionalidad completa para duplicar `Recipes` existentes, permitiendo a los usuarios crear copias de `Recipes` existentes
- Se refactorizó el componente `Card` para utilizar el componente `RecipeTags` reutilizable, mejorando la consistencia visual y mantenibilidad del código.

---

### 🧩 Tipo de cambio

- [X] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [X] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #52 

---

### 🗒️ Notas adicionales

**Capturas de Pantalla**
- Nuevo button para copiar `Recipe`
<img width="582" height="886" alt="image" src="https://github.com/user-attachments/assets/a251bfe1-2f44-45aa-80c6-7cd107296bc5" />

- Nueva vista para editar y guardar la nueva `Recipe`
<img width="1912" height="1000" alt="image" src="https://github.com/user-attachments/assets/e66c8af2-a826-46c1-8cb5-e5200596b102" />

---