### PR TITLE
Feature: Add usage count for metadata items in admin panel (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the `MisRegistros-Front` project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2025-09-21
+
+### Added
+
+- **Usage counters display**: Visualization of metadata usage statistics
+  - Total count of items in section headers (ingredients, categories, origins)
+  - Individual usage count of how many times each specific item is used in recipes, displayed next to the name
+- **Enhanced error messaging system**: Comprehensive error handling with user-friendly messages
+  - Specific error messages for backend validation failures (e.g., invalid ingredient units)
+  - Clear messaging for foreign key constraint violations when deleting referenced items
+  - Contextual error titles based on operation type (creation, update, deletion)
+- **Unified metadata endpoint**: Integration with `/metadata/usage-count` for optimized data fetching
+- **Custom hook architecture**: `useMetadataOperations` hook for better code organization
+- **Centralized message constants**: `MESSAGES` object for consistent UI text management
+
+### Fixed
+
+- **Duplicate error messages**: Resolved issue where both error and success toasts appeared simultaneously
+- **Message timing conflicts**: Eliminated race conditions in toast notifications
+- **Form validation feedback**: Improved error display for invalid ingredient units and empty name fields
+- **Foreign key constraint handling**: Better user messaging when attempting to delete items with dependencies
+
 ## [2.0.1] - 2025-09-03
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misregistros-front",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/recipe-book/pages/Meta.tsx
+++ b/src/features/recipe-book/pages/Meta.tsx
@@ -80,17 +80,26 @@ const getErrorMessage = (error: any): string => {
 interface Category {
   id: number;
   name: string;
+  usageCount?: number;
 }
 
 interface Origin {
   id: number;
   name: string;
+  usageCount?: number;
 }
 
 interface Ingredient {
   id: number;
   name: string;
   unit: string;
+  usageCount?: number;
+}
+
+interface MetadataWithUsage {
+  categories: Category[];
+  origins: Origin[];
+  ingredients: Ingredient[];
 }
 
 type MetaDataItem = Category | Origin | Ingredient;
@@ -187,6 +196,8 @@ const TableRow = React.memo<{
   loadingCrud: boolean;
   iconColor: string;
 }>(({ item, type, onEdit, onDelete, loadingCrud, iconColor }) => {
+  const countTextColor = useColorModeValue("gray.500", "gray.400");
+
   const handleEdit = useCallback(() => {
     onEdit(item, type);
   }, [item, type, onEdit]);
@@ -195,9 +206,23 @@ const TableRow = React.memo<{
     onDelete(item.id, type);
   }, [item.id, type, onDelete]);
 
+  const usageCount = "usageCount" in item ? item.usageCount || 0 : 0;
+
   return (
     <Tr>
-      <Td>{item.name}</Td>
+      <Td>
+        {item.name}{" "}
+        <Text
+          as="sub"
+          sx={{
+            color: countTextColor + " !important",
+            fontSize: "xs",
+          }}
+          fontWeight="normal"
+        >
+          ({usageCount})
+        </Text>
+      </Td>
       {type === "ingredient" && "unit" in item && (
         <Td textAlign="center">{item.unit}</Td>
       )}
@@ -237,7 +262,7 @@ const RecipeMetaPage: React.FC = () => {
 
   const countTextColor = useColorModeValue("gray.500", "gray.400");
 
-  const [itemUnit, setItemUnit] = useState("kg");
+  const [itemUnit, setItemUnit] = useState("");
   const availableUnits = [
     "mg",
     "g",
@@ -259,25 +284,11 @@ const RecipeMetaPage: React.FC = () => {
   const toast = useToast();
 
   const {
-    loading: loadingCategories,
-    data: categoriesData,
-    error: categoriesError,
-    axiosFetch: axiosFetchCategories,
-  } = useAxios<Category[]>();
-
-  const {
-    loading: loadingOrigins,
-    data: originsData,
-    error: originsError,
-    axiosFetch: axiosFetchOrigins,
-  } = useAxios<Origin[]>();
-
-  const {
-    loading: loadingIngredients,
-    data: ingredientsData,
-    error: ingredientsError,
-    axiosFetch: axiosFetchIngredients,
-  } = useAxios<Ingredient[]>();
+    loading: loadingMetadata,
+    data: metadataData,
+    error: metadataError,
+    axiosFetch: axiosFetchMetadata,
+  } = useAxios<MetadataWithUsage>();
 
   const {
     loading: loadingCrud,
@@ -293,64 +304,31 @@ const RecipeMetaPage: React.FC = () => {
   } = useAxios<any>();
 
   useEffect(() => {
-    axiosFetchCategories(HTTP_METHODS.GET, `${API_BASE_URL}/category`);
-    axiosFetchOrigins(HTTP_METHODS.GET, `${API_BASE_URL}/origin`);
-    axiosFetchIngredients(HTTP_METHODS.GET, `${API_BASE_URL}/ingredient`);
+    axiosFetchMetadata(
+      HTTP_METHODS.GET,
+      `${API_BASE_URL}/metadata/usage-count`
+    );
   }, []);
 
   useEffect(() => {
-    if (categoriesData) {
-      setCategories(categoriesData);
+    if (metadataData) {
+      setCategories(metadataData.categories || []);
+      setOrigins(metadataData.origins || []);
+      setIngredients(metadataData.ingredients || []);
     }
-  }, [categoriesData]);
+  }, [metadataData]);
 
   useEffect(() => {
-    if (originsData) {
-      setOrigins(originsData);
-    }
-  }, [originsData]);
-
-  useEffect(() => {
-    if (ingredientsData) {
-      setIngredients(ingredientsData);
-    }
-  }, [ingredientsData]);
-
-  useEffect(() => {
-    if (categoriesError) {
+    if (metadataError) {
       toast({
-        title: "Error al cargar categorías",
-        description: getErrorMessage(categoriesError),
+        title: "Error al cargar metadatos",
+        description: getErrorMessage(metadataError),
         status: "error",
         duration: 5000,
         isClosable: true,
       });
     }
-  }, [categoriesError, toast]);
-
-  useEffect(() => {
-    if (originsError) {
-      toast({
-        title: "Error al cargar orígenes",
-        description: getErrorMessage(originsError),
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    }
-  }, [originsError, toast]);
-
-  useEffect(() => {
-    if (ingredientsError) {
-      toast({
-        title: "Error al cargar ingredientes",
-        description: getErrorMessage(ingredientsError),
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    }
-  }, [ingredientsError, toast]);
+  }, [metadataError, toast]);
 
   useEffect(() => {
     if (crudError) {
@@ -378,13 +356,10 @@ const RecipeMetaPage: React.FC = () => {
 
   useEffect(() => {
     if (saveData !== undefined && !saveError) {
-      if (currentType === "category") {
-        axiosFetchCategories(HTTP_METHODS.GET, `${API_BASE_URL}/category`);
-      } else if (currentType === "origin") {
-        axiosFetchOrigins(HTTP_METHODS.GET, `${API_BASE_URL}/origin`);
-      } else {
-        axiosFetchIngredients(HTTP_METHODS.GET, `${API_BASE_URL}/ingredient`);
-      }
+      axiosFetchMetadata(
+        HTTP_METHODS.GET,
+        `${API_BASE_URL}/metadata/usage-count`
+      );
 
       toast({
         title: "Éxito",
@@ -407,9 +382,7 @@ const RecipeMetaPage: React.FC = () => {
     saveError,
     currentType,
     isEditing,
-    axiosFetchCategories,
-    axiosFetchOrigins,
-    axiosFetchIngredients,
+    axiosFetchMetadata,
     toast,
     onClose,
   ]);
@@ -460,13 +433,10 @@ const RecipeMetaPage: React.FC = () => {
         `${API_BASE_URL}/${endpoint}/${id}`
       );
 
-      if (type === "category") {
-        axiosFetchCategories(HTTP_METHODS.GET, `${API_BASE_URL}/category`);
-      } else if (type === "origin") {
-        axiosFetchOrigins(HTTP_METHODS.GET, `${API_BASE_URL}/origin`);
-      } else {
-        axiosFetchIngredients(HTTP_METHODS.GET, `${API_BASE_URL}/ingredient`);
-      }
+      axiosFetchMetadata(
+        HTTP_METHODS.GET,
+        `${API_BASE_URL}/metadata/usage-count`
+      );
 
       toast({
         title: "Éxito",
@@ -482,13 +452,7 @@ const RecipeMetaPage: React.FC = () => {
         isClosable: true,
       });
     },
-    [
-      performCrudOperation,
-      axiosFetchCategories,
-      axiosFetchOrigins,
-      axiosFetchIngredients,
-      toast,
-    ]
+    [performCrudOperation, axiosFetchMetadata, toast]
   );
 
   const handleSave = async () => {
@@ -563,7 +527,7 @@ const RecipeMetaPage: React.FC = () => {
                 <Button
                   variant="greenButton"
                   onClick={() => handleAddNew("ingredient")}
-                  isLoading={loadingIngredients}
+                  isLoading={loadingMetadata}
                 >
                   Agregar
                 </Button>
@@ -573,7 +537,7 @@ const RecipeMetaPage: React.FC = () => {
               <DataTable
                 data={ingredients}
                 type="ingredient"
-                loading={loadingIngredients}
+                loading={loadingMetadata}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 loadingCrud={loadingCrud}
@@ -603,7 +567,7 @@ const RecipeMetaPage: React.FC = () => {
                 <Button
                   variant="greenButton"
                   onClick={() => handleAddNew("category")}
-                  isLoading={loadingCategories}
+                  isLoading={loadingMetadata}
                 >
                   Agregar
                 </Button>
@@ -613,7 +577,7 @@ const RecipeMetaPage: React.FC = () => {
               <DataTable
                 data={categories}
                 type="category"
-                loading={loadingCategories}
+                loading={loadingMetadata}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 loadingCrud={loadingCrud}
@@ -643,7 +607,7 @@ const RecipeMetaPage: React.FC = () => {
                 <Button
                   variant="greenButton"
                   onClick={() => handleAddNew("origin")}
-                  isLoading={loadingOrigins}
+                  isLoading={loadingMetadata}
                 >
                   Agregar
                 </Button>
@@ -653,7 +617,7 @@ const RecipeMetaPage: React.FC = () => {
               <DataTable
                 data={origins}
                 type="origin"
-                loading={loadingOrigins}
+                loading={loadingMetadata}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 loadingCrud={loadingCrud}

--- a/src/features/recipe-book/pages/Meta.tsx
+++ b/src/features/recipe-book/pages/Meta.tsx
@@ -39,6 +39,43 @@ import useAxios from "../../../shared/hooks/axiosFetch";
 import { API_BASE_URL } from "../../../shared/constants/environment";
 import { HTTP_METHODS } from "../../../shared/constants/httpMethods";
 
+const getErrorMessage = (error: any): string => {
+  if (error?.response?.data) {
+    const responseData = error.response.data;
+
+    if (
+      responseData.data?.validations &&
+      responseData.data.validations.length > 0
+    ) {
+      if (responseData.data.validations.length === 1) {
+        return responseData.data.validations[0].message;
+      } else {
+        return responseData.data.validations
+          .map((validation: any) => validation.message)
+          .join(". ");
+      }
+    }
+
+    if (responseData.validations && responseData.validations.length > 0) {
+      if (responseData.validations.length === 1) {
+        return responseData.validations[0].message;
+      } else {
+        return responseData.validations
+          .map((validation: any) => validation.message)
+          .join(". ");
+      }
+    }
+
+    if (responseData.data?.details) return responseData.data.details;
+    if (responseData.details) return responseData.details;
+    if (responseData.data?.error) return responseData.data.error;
+    if (responseData.message) return responseData.message;
+    if (responseData.error) return responseData.error;
+  }
+
+  return error?.message || "Error desconocido";
+};
+
 interface Category {
   id: number;
   name: string;
@@ -199,14 +236,17 @@ const RecipeMetaPage: React.FC = () => {
 
   const [itemUnit, setItemUnit] = useState("kg");
   const availableUnits = [
-    "kg",
+    "mg",
     "g",
-    "l",
+    "kg",
     "ml",
-    "unidad",
-    "cucharada",
-    "cucharadita",
-    "taza",
+    "cl",
+    "l",
+    "u",
+    "tsp",
+    "tbsp",
+    "cup",
+    "pinch",
   ];
 
   const [itemName, setItemName] = useState("");
@@ -242,6 +282,13 @@ const RecipeMetaPage: React.FC = () => {
     axiosFetch: performCrudOperation,
   } = useAxios<any>();
 
+  const {
+    loading: loadingSave,
+    data: saveData,
+    error: saveError,
+    axiosFetch: performSaveOperation,
+  } = useAxios<any>();
+
   useEffect(() => {
     axiosFetchCategories(HTTP_METHODS.GET, `${API_BASE_URL}/category`);
     axiosFetchOrigins(HTTP_METHODS.GET, `${API_BASE_URL}/origin`);
@@ -270,7 +317,7 @@ const RecipeMetaPage: React.FC = () => {
     if (categoriesError) {
       toast({
         title: "Error al cargar categorías",
-        description: categoriesError.message,
+        description: getErrorMessage(categoriesError),
         status: "error",
         duration: 5000,
         isClosable: true,
@@ -282,7 +329,7 @@ const RecipeMetaPage: React.FC = () => {
     if (originsError) {
       toast({
         title: "Error al cargar orígenes",
-        description: originsError.message,
+        description: getErrorMessage(originsError),
         status: "error",
         duration: 5000,
         isClosable: true,
@@ -294,7 +341,7 @@ const RecipeMetaPage: React.FC = () => {
     if (ingredientsError) {
       toast({
         title: "Error al cargar ingredientes",
-        description: ingredientsError.message,
+        description: getErrorMessage(ingredientsError),
         status: "error",
         duration: 5000,
         isClosable: true,
@@ -306,13 +353,63 @@ const RecipeMetaPage: React.FC = () => {
     if (crudError) {
       toast({
         title: "Error al realizar la operación",
-        description: crudError.message,
+        description: getErrorMessage(crudError),
         status: "error",
         duration: 5000,
         isClosable: true,
       });
     }
   }, [crudError, toast]);
+
+  useEffect(() => {
+    if (saveError) {
+      toast({
+        title: "Error al guardar",
+        description: getErrorMessage(saveError),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  }, [saveError, toast]);
+
+  useEffect(() => {
+    if (saveData !== undefined && !saveError) {
+      if (currentType === "category") {
+        axiosFetchCategories(HTTP_METHODS.GET, `${API_BASE_URL}/category`);
+      } else if (currentType === "origin") {
+        axiosFetchOrigins(HTTP_METHODS.GET, `${API_BASE_URL}/origin`);
+      } else {
+        axiosFetchIngredients(HTTP_METHODS.GET, `${API_BASE_URL}/ingredient`);
+      }
+
+      toast({
+        title: "Éxito",
+        description: `${
+          currentType === "category"
+            ? "Categoría"
+            : currentType === "origin"
+            ? "Origen"
+            : "Ingrediente"
+        } ${isEditing ? "actualizado" : "creado"} correctamente`,
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+
+      onClose();
+    }
+  }, [
+    saveData,
+    saveError,
+    currentType,
+    isEditing,
+    axiosFetchCategories,
+    axiosFetchOrigins,
+    axiosFetchIngredients,
+    toast,
+    onClose,
+  ]);
 
   const handleAddNew = useCallback(
     (type: MetaDataType) => {
@@ -322,7 +419,7 @@ const RecipeMetaPage: React.FC = () => {
       setItemName("");
 
       if (type === "ingredient") {
-        setItemUnit("kg");
+        setItemUnit("u");
       }
 
       onOpen();
@@ -421,31 +518,7 @@ const RecipeMetaPage: React.FC = () => {
         ? { name: itemName, unit: itemUnit }
         : { name: itemName };
 
-    await performCrudOperation(method, url, data);
-
-    if (currentType === "category") {
-      axiosFetchCategories(HTTP_METHODS.GET, `${API_BASE_URL}/category`);
-    } else if (currentType === "origin") {
-      axiosFetchOrigins(HTTP_METHODS.GET, `${API_BASE_URL}/origin`);
-    } else {
-      axiosFetchIngredients(HTTP_METHODS.GET, `${API_BASE_URL}/ingredient`);
-    }
-
-    toast({
-      title: "Éxito",
-      description: `${
-        currentType === "category"
-          ? "Categoría"
-          : currentType === "origin"
-          ? "Origen"
-          : "Ingrediente"
-      } ${isEditing ? "actualizado" : "creado"} correctamente`,
-      status: "success",
-      duration: 3000,
-      isClosable: true,
-    });
-
-    onClose();
+    await performSaveOperation(method, url, data);
   };
 
   const modalTitle = useMemo(() => {
@@ -596,7 +669,7 @@ const RecipeMetaPage: React.FC = () => {
             <Button
               variant="greenButton"
               onClick={handleSave}
-              isLoading={loadingCrud}
+              isLoading={loadingSave}
             >
               Guardar
             </Button>

--- a/src/features/recipe-book/pages/Meta.tsx
+++ b/src/features/recipe-book/pages/Meta.tsx
@@ -20,6 +20,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Select,
+  Spacer,
   Table,
   TableContainer,
   Tbody,
@@ -233,6 +234,8 @@ const RecipeMetaPage: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [currentItem, setCurrentItem] = useState<MetaDataItem | null>(null);
   const [currentType, setCurrentType] = useState<MetaDataType>("category");
+
+  const countTextColor = useColorModeValue("gray.500", "gray.400");
 
   const [itemUnit, setItemUnit] = useState("kg");
   const availableUnits = [
@@ -544,9 +547,19 @@ const RecipeMetaPage: React.FC = () => {
           <Card height="100%" display="flex" flexDirection="column">
             <CardHeader mb={-4}>
               <Flex justify="space-between" align="center">
-                <Heading size="md" ml={2}>
+                <Heading size="md" mx={2}>
                   Ingredientes
                 </Heading>
+                <Text
+                  as="sub"
+                  sx={{
+                    color: countTextColor + " !important",
+                    fontSize: "sm",
+                  }}
+                >
+                  ({ingredients.length})
+                </Text>
+                <Spacer />
                 <Button
                   variant="greenButton"
                   onClick={() => handleAddNew("ingredient")}
@@ -574,9 +587,19 @@ const RecipeMetaPage: React.FC = () => {
           <Card height="100%" display="flex" flexDirection="column">
             <CardHeader mb={-4}>
               <Flex justify="space-between" align="center">
-                <Heading size="md" ml={2}>
+                <Heading size="md" mx={2}>
                   Categorías
                 </Heading>
+                <Text
+                  as="sub"
+                  sx={{
+                    color: countTextColor + " !important",
+                    fontSize: "sm",
+                  }}
+                >
+                  ({categories.length})
+                </Text>
+                <Spacer />
                 <Button
                   variant="greenButton"
                   onClick={() => handleAddNew("category")}
@@ -604,9 +627,19 @@ const RecipeMetaPage: React.FC = () => {
           <Card height="100%" display="flex" flexDirection="column">
             <CardHeader mb={-4}>
               <Flex justify="space-between" align="center">
-                <Heading size="md" ml={2}>
+                <Heading size="md" mx={2}>
                   Orígen
                 </Heading>
+                <Text
+                  as="sub"
+                  sx={{
+                    color: countTextColor + " !important",
+                    fontSize: "sm",
+                  }}
+                >
+                  ({origins.length})
+                </Text>
+                <Spacer />
                 <Button
                   variant="greenButton"
                   onClick={() => handleAddNew("origin")}

--- a/src/features/recipe-book/pages/Meta.tsx
+++ b/src/features/recipe-book/pages/Meta.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Box,
   Button,
@@ -40,41 +46,77 @@ import useAxios from "../../../shared/hooks/axiosFetch";
 import { API_BASE_URL } from "../../../shared/constants/environment";
 import { HTTP_METHODS } from "../../../shared/constants/httpMethods";
 
+const MESSAGES = {
+  ERROR: {
+    LOAD_METADATA: "Error al cargar metadatos",
+    CRUD_OPERATION: "Error al realizar la operación",
+    SAVE: "Error al guardar",
+    DELETE_CONFLICT: "No se puede eliminar",
+    EMPTY_NAME: "El nombre no puede estar vacío",
+    CONFLICT_DETAIL: "Está siendo usado en al menos una receta.",
+    UNKNOWN: "Error desconocido",
+  },
+  SUCCESS: {
+    DELETED: "eliminado correctamente",
+    CREATED: "creado correctamente",
+    UPDATED: "actualizado correctamente",
+  },
+  LOADING: {
+    INGREDIENTS: "Cargando ingredientes...",
+    CATEGORIES: "Cargando categorías...",
+    ORIGINS: "Cargando orígenes...",
+  },
+  NOT_FOUND: {
+    INGREDIENTS: "No se encontraron ingredientes",
+    CATEGORIES: "No se encontraron categorías",
+    ORIGINS: "No se encontraron orígenes",
+  },
+};
+
+const getEntityName = (type: MetaDataType) => {
+  switch (type) {
+    case "category":
+      return "Categoría";
+    case "origin":
+      return "Origen";
+    case "ingredient":
+      return "Ingrediente";
+    default:
+      return "";
+  }
+};
+
+const isAxiosError = (error: any): error is { response?: { data?: any } } => {
+  return error && typeof error === "object" && "response" in error;
+};
+
 const getErrorMessage = (error: any): string => {
-  if (error?.response?.data) {
+  if (isAxiosError(error) && error.response?.data) {
     const responseData = error.response.data;
 
-    if (
-      responseData.data?.validations &&
-      responseData.data.validations.length > 0
-    ) {
-      if (responseData.data.validations.length === 1) {
-        return responseData.data.validations[0].message;
-      } else {
-        return responseData.data.validations
-          .map((validation: any) => validation.message)
-          .join(". ");
-      }
+    if (responseData.error === "Conflict" && responseData.details) {
+      return MESSAGES.ERROR.CONFLICT_DETAIL;
     }
 
-    if (responseData.validations && responseData.validations.length > 0) {
-      if (responseData.validations.length === 1) {
-        return responseData.validations[0].message;
-      } else {
-        return responseData.validations
-          .map((validation: any) => validation.message)
-          .join(". ");
-      }
+    const validations =
+      responseData.data?.validations || responseData.validations;
+    if (validations && validations.length > 0) {
+      return validations.length === 1
+        ? validations[0].message
+        : validations.map((v: any) => v.message).join(". ");
     }
 
-    if (responseData.data?.details) return responseData.data.details;
-    if (responseData.details) return responseData.details;
-    if (responseData.data?.error) return responseData.data.error;
-    if (responseData.message) return responseData.message;
-    if (responseData.error) return responseData.error;
+    return (
+      responseData.data?.details ||
+      responseData.details ||
+      responseData.data?.error ||
+      responseData.message ||
+      responseData.error ||
+      MESSAGES.ERROR.UNKNOWN
+    );
   }
 
-  return error?.message || "Error desconocido";
+  return error?.message || MESSAGES.ERROR.UNKNOWN;
 };
 
 interface Category {
@@ -105,6 +147,117 @@ interface MetadataWithUsage {
 type MetaDataItem = Category | Origin | Ingredient;
 type MetaDataType = "category" | "origin" | "ingredient";
 
+const useMetadataOperations = () => {
+  const toast = useToast();
+  const deleteContextRef = useRef<{
+    type: MetaDataType;
+    itemName: string;
+  } | null>(null);
+
+  const {
+    loading: loadingMetadata,
+    data: metadataData,
+    error: metadataError,
+    axiosFetch: fetchMetadata,
+  } = useAxios<MetadataWithUsage>();
+
+  const {
+    loading: loadingCrud,
+    data: crudData,
+    error: crudError,
+    axiosFetch: performCrudOperation,
+  } = useAxios<any>();
+
+  const {
+    loading: loadingSave,
+    data: saveData,
+    error: saveError,
+    axiosFetch: performSaveOperation,
+  } = useAxios<any>();
+
+  const refreshMetadata = useCallback(() => {
+    fetchMetadata(HTTP_METHODS.GET, `${API_BASE_URL}/metadata/usage-count`);
+  }, [fetchMetadata]);
+
+  useEffect(() => {
+    if (crudError) {
+      const errorMessage = getErrorMessage(crudError);
+      const isConflictError =
+        isAxiosError(crudError) &&
+        crudError?.response?.data?.error === "Conflict";
+
+      toast({
+        title: isConflictError
+          ? MESSAGES.ERROR.DELETE_CONFLICT
+          : MESSAGES.ERROR.CRUD_OPERATION,
+        description: errorMessage,
+        status: "error",
+        duration: isConflictError ? 6000 : 5000,
+        isClosable: true,
+      });
+
+      deleteContextRef.current = null;
+    }
+  }, [crudError, toast]);
+
+  useEffect(() => {
+    if (deleteContextRef.current && crudData !== undefined && !crudError) {
+      refreshMetadata();
+
+      toast({
+        title: "Éxito",
+        description: `${getEntityName(deleteContextRef.current.type)} ${
+          MESSAGES.SUCCESS.DELETED
+        }`,
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+
+      deleteContextRef.current = null;
+    }
+  }, [crudData, crudError, refreshMetadata, toast]);
+
+  useEffect(() => {
+    if (saveError) {
+      toast({
+        title: MESSAGES.ERROR.SAVE,
+        description: getErrorMessage(saveError),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  }, [saveError, toast]);
+
+  useEffect(() => {
+    if (metadataError) {
+      toast({
+        title: MESSAGES.ERROR.LOAD_METADATA,
+        description: getErrorMessage(metadataError),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  }, [metadataError, toast]);
+
+  return {
+    // Estados
+    loadingMetadata,
+    loadingCrud,
+    loadingSave,
+    metadataData,
+    saveData,
+    saveError,
+    // Funciones
+    refreshMetadata,
+    performCrudOperation,
+    performSaveOperation,
+    deleteContextRef,
+  };
+};
+
 const DataTable = React.memo<{
   data: MetaDataItem[];
   type: MetaDataType;
@@ -119,13 +272,11 @@ const DataTable = React.memo<{
   if (loading) {
     return (
       <Text>
-        Cargando{" "}
         {type === "ingredient"
-          ? "ingredientes"
+          ? MESSAGES.LOADING.INGREDIENTS
           : type === "category"
-          ? "categorías"
-          : "orígenes"}
-        ...
+          ? MESSAGES.LOADING.CATEGORIES
+          : MESSAGES.LOADING.ORIGINS}
       </Text>
     );
   }
@@ -133,12 +284,11 @@ const DataTable = React.memo<{
   if (data.length === 0) {
     return (
       <Text>
-        No se encontraron{" "}
         {type === "ingredient"
-          ? "ingredientes"
+          ? MESSAGES.NOT_FOUND.INGREDIENTS
           : type === "category"
-          ? "categorías"
-          : "orígenes"}
+          ? MESSAGES.NOT_FOUND.CATEGORIES
+          : MESSAGES.NOT_FOUND.ORIGINS}
       </Text>
     );
   }
@@ -278,37 +428,25 @@ const RecipeMetaPage: React.FC = () => {
   ];
 
   const [itemName, setItemName] = useState("");
-
   const { isOpen, onOpen, onClose } = useDisclosure();
-
   const toast = useToast();
 
   const {
-    loading: loadingMetadata,
-    data: metadataData,
-    error: metadataError,
-    axiosFetch: axiosFetchMetadata,
-  } = useAxios<MetadataWithUsage>();
-
-  const {
-    loading: loadingCrud,
-    error: crudError,
-    axiosFetch: performCrudOperation,
-  } = useAxios<any>();
-
-  const {
-    loading: loadingSave,
-    data: saveData,
-    error: saveError,
-    axiosFetch: performSaveOperation,
-  } = useAxios<any>();
+    loadingMetadata,
+    loadingCrud,
+    loadingSave,
+    metadataData,
+    saveData,
+    saveError,
+    refreshMetadata,
+    performCrudOperation,
+    performSaveOperation,
+    deleteContextRef,
+  } = useMetadataOperations();
 
   useEffect(() => {
-    axiosFetchMetadata(
-      HTTP_METHODS.GET,
-      `${API_BASE_URL}/metadata/usage-count`
-    );
-  }, []);
+    refreshMetadata();
+  }, [refreshMetadata]);
 
   useEffect(() => {
     if (metadataData) {
@@ -319,57 +457,14 @@ const RecipeMetaPage: React.FC = () => {
   }, [metadataData]);
 
   useEffect(() => {
-    if (metadataError) {
-      toast({
-        title: "Error al cargar metadatos",
-        description: getErrorMessage(metadataError),
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    }
-  }, [metadataError, toast]);
-
-  useEffect(() => {
-    if (crudError) {
-      toast({
-        title: "Error al realizar la operación",
-        description: getErrorMessage(crudError),
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    }
-  }, [crudError, toast]);
-
-  useEffect(() => {
-    if (saveError) {
-      toast({
-        title: "Error al guardar",
-        description: getErrorMessage(saveError),
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    }
-  }, [saveError, toast]);
-
-  useEffect(() => {
     if (saveData !== undefined && !saveError) {
-      axiosFetchMetadata(
-        HTTP_METHODS.GET,
-        `${API_BASE_URL}/metadata/usage-count`
-      );
+      refreshMetadata();
 
       toast({
         title: "Éxito",
-        description: `${
-          currentType === "category"
-            ? "Categoría"
-            : currentType === "origin"
-            ? "Origen"
-            : "Ingrediente"
-        } ${isEditing ? "actualizado" : "creado"} correctamente`,
+        description: `${getEntityName(currentType)} ${
+          isEditing ? MESSAGES.SUCCESS.UPDATED : MESSAGES.SUCCESS.CREATED
+        }`,
         status: "success",
         duration: 3000,
         isClosable: true,
@@ -382,7 +477,7 @@ const RecipeMetaPage: React.FC = () => {
     saveError,
     currentType,
     isEditing,
-    axiosFetchMetadata,
+    refreshMetadata,
     toast,
     onClose,
   ]);
@@ -428,38 +523,30 @@ const RecipeMetaPage: React.FC = () => {
           ? "origin"
           : "ingredient";
 
+      let itemName = "";
+      if (type === "category") {
+        itemName = categories.find((c) => c.id === id)?.name || "";
+      } else if (type === "origin") {
+        itemName = origins.find((o) => o.id === id)?.name || "";
+      } else {
+        itemName = ingredients.find((i) => i.id === id)?.name || "";
+      }
+
+      deleteContextRef.current = { type, itemName };
+
       await performCrudOperation(
         HTTP_METHODS.DELETE,
         `${API_BASE_URL}/${endpoint}/${id}`
       );
-
-      axiosFetchMetadata(
-        HTTP_METHODS.GET,
-        `${API_BASE_URL}/metadata/usage-count`
-      );
-
-      toast({
-        title: "Éxito",
-        description: `${
-          type === "category"
-            ? "Categoría"
-            : type === "origin"
-            ? "Origen"
-            : "Ingrediente"
-        } eliminado correctamente`,
-        status: "success",
-        duration: 3000,
-        isClosable: true,
-      });
     },
-    [performCrudOperation, axiosFetchMetadata, toast]
+    [performCrudOperation, categories, origins, ingredients]
   );
 
   const handleSave = async () => {
     if (!itemName.trim()) {
       toast({
         title: "Error",
-        description: "El nombre no puede estar vacío",
+        description: MESSAGES.ERROR.EMPTY_NAME,
         status: "error",
         duration: 3000,
         isClosable: true,
@@ -473,13 +560,10 @@ const RecipeMetaPage: React.FC = () => {
         : currentType === "origin"
         ? "origin"
         : "ingredient";
-
     const method = isEditing ? HTTP_METHODS.PATCH : HTTP_METHODS.POST;
-
     const url = isEditing
       ? `${API_BASE_URL}/${endpoint}/${currentItem?.id}`
       : `${API_BASE_URL}/${endpoint}`;
-
     const data =
       currentType === "ingredient"
         ? { name: itemName, unit: itemUnit }
@@ -490,13 +574,7 @@ const RecipeMetaPage: React.FC = () => {
 
   const modalTitle = useMemo(() => {
     const action = isEditing ? "Editar" : "Crear";
-    const entityType =
-      currentType === "category"
-        ? "Categoría"
-        : currentType === "origin"
-        ? "Origen"
-        : "Ingrediente";
-    return `${action} ${entityType}`;
+    return `${action} ${getEntityName(currentType)}`;
   }, [isEditing, currentType]);
 
   return (


### PR DESCRIPTION
### 📋 Resumen

Mejora significativa de la UI/UX en la vista de administración de metadatos de recetas, implementando visualización de contadores de uso y optimizando el manejo de errores para una mejor experiencia de usuario.

**Funcionalidades principales:**
- **Contadores de uso**: Muestra el total de metadatos en los títulos de cada sección (ingredientes, categorías, orígenes)
- **Contadores individuales**: Visualiza cuántas veces se usa cada ítem específico en las recetas, mostrado junto al nombre
- **Manejo de errores mejorado**: Mensajes específicos y amigables para diferentes tipos de errores
- **Refactor arquitectural**: Custom hook `useMetadataOperations` para mejor separación de responsabilidades

**Mejoras en manejo de errores:**
1. **Validaciones de backend**: Mensajes claros cuando se intenta crear un ingrediente con unidad inválida
2. **Restricciones de integridad**: Mensaje específico al intentar eliminar elementos con referencias en recetas ("Está siendo usado en al menos una receta")
3. **Eliminación de mensajes duplicados**: Solución al problema de mostrar tanto error como éxito simultáneamente

---

### 🧩 Tipo de cambio

- [X] ✨ Feature (nueva funcionalidad)
- [X] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [X] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #54 

---

### 🗒️ Notas adicionales

**Compatibilidad:**
- Requiere endpoint backend `/metadata/usage-count`

**Capturas de Pantalla**

Vista de `Metadatos` actualizada

<img width="1912" height="1000" alt="image" src="https://github.com/user-attachments/assets/7f4e86ab-1afe-47de-854a-9cdca3391c96" />

---