### PR TITLE
Feature/67 upload image of recipe

### DIFF
--- a/src/features/recipe-book/pages/Create.tsx
+++ b/src/features/recipe-book/pages/Create.tsx
@@ -110,26 +110,41 @@ const CreateRecipePage = () => {
         return;
       }
 
-      const bodyRecipe = {
-        idCategory: data.selectedCategory.id,
-        idOrigin: data.selectedOrigin.id,
-        name: data.name,
-        description: data.description,
-        score: parseInt(data.score),
-        time: parseInt(data.time),
-        servings: data.servings,
-        ...(data.thumbnail?.trim() && { thumbnail: data.thumbnail }),
-        ingredients: data.ingredients.map((ingredient: IngredientFormData) => ({
-          id: parseInt(ingredient.id),
-          quantity: parseFloat(ingredient.quantity),
-        })),
-        steps: data.steps.split("\n").map((step: string, index: number) => ({
-          number: index + 1,
-          instruction: step,
-        })),
-      };
+      const formData = new FormData();
+      formData.append("name", data.name);
+      formData.append("description", data.description);
+      formData.append("idCategory", String(data.selectedCategory.id));
+      formData.append("idOrigin", String(data.selectedOrigin.id));
+      formData.append("score", String(parseInt(data.score)));
+      formData.append("time", String(parseInt(data.time)));
+      formData.append("servings", String(data.servings));
+      formData.append(
+        "ingredients",
+        JSON.stringify(
+          data.ingredients.map((ingredient: IngredientFormData) => ({
+            id: parseInt(ingredient.id),
+            quantity: parseFloat(ingredient.quantity),
+          }))
+        )
+      );
+      formData.append(
+        "steps",
+        JSON.stringify(
+          data.steps
+            .split("\n")
+            .filter((s: string) => s.trim())
+            .map((step: string, index: number) => ({
+              number: index + 1,
+              instruction: step,
+            }))
+        )
+      );
 
-      await axiosFetch(HTTP_METHODS.POST, `${API_BASE_URL}/recipe`, bodyRecipe);
+      if (data.thumbnailFile) {
+        formData.append("thumbnail", data.thumbnailFile);
+      }
+
+      await axiosFetch(HTTP_METHODS.POST, `${API_BASE_URL}/recipe`, formData);
 
       toast({
         position: "top",
@@ -145,11 +160,12 @@ const CreateRecipePage = () => {
       });
 
       navigate("/recipes");
-    } catch (error) {
+    } catch (error: any) {
+      const apiMessage = error?.response?.data?.details;
       toast({
         position: "top",
         title: "Error al crear receta",
-        description: "Por favor intente nuevamente.",
+        description: apiMessage ?? "Por favor intente nuevamente.",
         status: "error",
         duration: 3000,
         isClosable: true,

--- a/src/features/recipe-book/pages/Update.tsx
+++ b/src/features/recipe-book/pages/Update.tsx
@@ -12,7 +12,7 @@ import {
 import useAxios from "../../../shared/hooks/axiosFetch";
 import {
   RecipeForm,
-  RecipeFormData,
+  RecipeFormSubmissionData,
   RecipeFormButtons,
 } from "../../../shared/components/forms";
 import { API_BASE_URL } from "../../../shared/constants/environment";
@@ -38,32 +38,46 @@ const UpdateRecipePage = () => {
     }
   }, [id, fetchRecipe]);
 
-  const handleSubmit = async (formData: RecipeFormData) => {
-    const bodyRecipe = {
-      idCategory: formData.selectedCategory?.id,
-      idOrigin: formData.selectedOrigin?.id,
-      name: formData.name,
-      description: formData.description,
-      score: parseInt(formData.score),
-      time: parseInt(formData.time),
-      servings: formData.servings,
-      ...(formData.thumbnail?.trim() && { thumbnail: formData.thumbnail }),
-      ingredients:
-        formData.ingredients?.map((ingredient) => ({
+  const handleSubmit = async (formData: RecipeFormSubmissionData) => {
+    const body = new FormData();
+    body.append("name", formData.name);
+    body.append("description", formData.description);
+    body.append("idCategory", String(formData.selectedCategory?.id));
+    body.append("idOrigin", String(formData.selectedOrigin?.id));
+    body.append("score", String(parseInt(formData.score)));
+    body.append("time", String(parseInt(formData.time)));
+    body.append("servings", String(formData.servings));
+    body.append(
+      "ingredients",
+      JSON.stringify(
+        (formData.ingredients ?? []).map((ingredient) => ({
           id: parseInt(ingredient.id),
           quantity: parseFloat(ingredient.quantity),
-        })) || [],
-      steps: formData.steps.split("\n").map((step: string, index: number) => ({
-        number: index + 1,
-        instruction: step,
-      })),
-    };
+        }))
+      )
+    );
+    body.append(
+      "steps",
+      JSON.stringify(
+        formData.steps
+          .split("\n")
+          .filter((s: string) => s.trim())
+          .map((step: string, index: number) => ({
+            number: index + 1,
+            instruction: step,
+          }))
+      )
+    );
+
+    if (formData.thumbnailFile) {
+      body.append("thumbnail", formData.thumbnailFile);
+    }
 
     try {
       await updateRecipe(
         HTTP_METHODS.PATCH,
         `${API_BASE_URL}/recipe/${id}`,
-        bodyRecipe
+        body
       );
 
       toast({
@@ -76,12 +90,12 @@ const UpdateRecipePage = () => {
       });
 
       navigate("/recipes");
-    } catch (error) {
+    } catch (error: any) {
+      const apiMessage = error?.response?.data?.details;
       toast({
         position: "top",
         title: "Error",
-        description:
-          "Hubo un error al actualizar la receta. Inténtalo de nuevo.",
+        description: apiMessage ?? "Hubo un error al actualizar la receta. Inténtalo de nuevo.",
         status: "error",
         duration: 3000,
         isClosable: true,

--- a/src/shared/components/forms/RecipeForm/RecipeForm.tsx
+++ b/src/shared/components/forms/RecipeForm/RecipeForm.tsx
@@ -18,6 +18,9 @@ const RecipeForm = ({ initialData, onSubmit }: RecipeFormProps) => {
     setValue,
     watch,
     formState: { errors },
+    thumbnailFile,
+    setThumbnailFile,
+    existingThumbnailUrl,
     selectedCategory,
     setSelectedCategory,
     selectedOrigin,
@@ -38,6 +41,7 @@ const RecipeForm = ({ initialData, onSubmit }: RecipeFormProps) => {
       selectedCategory,
       selectedOrigin,
       ingredients,
+      thumbnailFile,
     };
     await onSubmit(formDataWithMetadata);
   };
@@ -47,7 +51,13 @@ const RecipeForm = ({ initialData, onSubmit }: RecipeFormProps) => {
       <Grid templateColumns="repeat(2, 1fr)" gap={6}>
         <GridItem>
           <VStack align="stretch" spacing={6}>
-            <BasicInfoSection register={register} errors={errors} />
+            <BasicInfoSection
+              register={register}
+              errors={errors}
+              thumbnailFile={thumbnailFile}
+              setThumbnailFile={setThumbnailFile}
+              existingThumbnailUrl={existingThumbnailUrl}
+            />
 
             <MetadataSection
               register={register}

--- a/src/shared/components/forms/RecipeForm/index.ts
+++ b/src/shared/components/forms/RecipeForm/index.ts
@@ -4,6 +4,7 @@ export { useRecipeForm } from "./useRecipeForm";
 export type {
   RecipeFormProps,
   RecipeFormData,
+  RecipeFormSubmissionData,
   RecipeFormButtonsProps,
   BasicInfoSectionProps,
   MetadataSectionProps,

--- a/src/shared/components/forms/RecipeForm/sections/BasicInfoSection.tsx
+++ b/src/shared/components/forms/RecipeForm/sections/BasicInfoSection.tsx
@@ -7,9 +7,16 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
+import { ImageUpload } from "../../../ui/ImageUpload";
 import { BasicInfoSectionProps } from "../types";
 
-const BasicInfoSection = ({ register, errors }: BasicInfoSectionProps) => {
+const BasicInfoSection = ({
+  register,
+  errors,
+  thumbnailFile,
+  setThumbnailFile,
+  existingThumbnailUrl,
+}: BasicInfoSectionProps) => {
   return (
     <VStack align="stretch" spacing={4}>
       <FormControl isRequired isInvalid={!!errors?.name}>
@@ -42,19 +49,13 @@ const BasicInfoSection = ({ register, errors }: BasicInfoSectionProps) => {
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
 
-      <FormControl isInvalid={!!errors?.thumbnail}>
-        <FormLabel>Imagen (URL)</FormLabel>
-        <Input
-          {...register("thumbnail", {
-            pattern: {
-              value:
-                /^https?:\/\/[^\s]+$/,
-              message: "Ingresa una URL válida que comience con http:// o https://",
-            },
-          })}
-          placeholder="https://ejemplo.com/imagen.jpg"
+      <FormControl>
+        <FormLabel>Imagen</FormLabel>
+        <ImageUpload
+          value={thumbnailFile}
+          onChange={setThumbnailFile}
+          existingUrl={existingThumbnailUrl}
         />
-        <FormErrorMessage>{errors?.thumbnail?.message}</FormErrorMessage>
       </FormControl>
     </VStack>
   );

--- a/src/shared/components/forms/RecipeForm/sections/StepsSection.tsx
+++ b/src/shared/components/forms/RecipeForm/sections/StepsSection.tsx
@@ -9,10 +9,14 @@ import { StepsSectionProps } from "../types";
 
 const StepsSection = ({ register, errors }: StepsSectionProps) => {
   return (
-    <FormControl isInvalid={!!errors?.steps}>
+    <FormControl isRequired isInvalid={!!errors?.steps}>
       <FormLabel>Pasos</FormLabel>
       <Textarea
-        {...register("steps")}
+        {...register("steps", {
+          validate: (value) =>
+            value.split("\n").some((s) => s.trim()) ||
+            "Debe agregar al menos un paso",
+        })}
         rows={7}
         size="sm"
         resize="none"

--- a/src/shared/components/forms/RecipeForm/types.ts
+++ b/src/shared/components/forms/RecipeForm/types.ts
@@ -14,7 +14,6 @@ import {
 export interface RecipeFormData {
   name: string;
   description: string;
-  thumbnail?: string;
   score: string;
   time: string;
   servings: number;
@@ -27,6 +26,9 @@ export interface RecipeFormData {
 export interface BasicInfoSectionProps {
   register: UseFormRegister<RecipeFormData>;
   errors?: FieldErrors<RecipeFormData>;
+  thumbnailFile: File | null;
+  setThumbnailFile: (file: File | null) => void;
+  existingThumbnailUrl?: string;
 }
 
 export interface MetadataSectionProps {
@@ -77,4 +79,5 @@ export interface RecipeFormSubmissionData extends RecipeFormData {
   selectedCategory: Category;
   selectedOrigin: Origin;
   ingredients: IngredientFormData[];
+  thumbnailFile?: File | null;
 }

--- a/src/shared/components/forms/RecipeForm/useRecipeForm.ts
+++ b/src/shared/components/forms/RecipeForm/useRecipeForm.ts
@@ -25,7 +25,6 @@ export const useRecipeForm = (initialData?: Recipe) => {
     defaultValues: {
       name: "",
       description: "",
-      thumbnail: "",
       score: "",
       time: "",
       servings: 1,
@@ -34,6 +33,9 @@ export const useRecipeForm = (initialData?: Recipe) => {
   });
 
   const { setValue, reset, watch } = form;
+
+  const [thumbnailFile, setThumbnailFile] = useState<File | null>(null);
+  const [existingThumbnailUrl, setExistingThumbnailUrl] = useState<string | undefined>(undefined);
 
   // Estados para categorías, orígenes e ingredientes
   const [selectedCategory, setSelectedCategory] =
@@ -72,7 +74,7 @@ export const useRecipeForm = (initialData?: Recipe) => {
     if (initialData) {
       setValue("name", initialData.name);
       setValue("description", initialData.description);
-      setValue("thumbnail", initialData.thumbnail || "");
+      setExistingThumbnailUrl(initialData.thumbnail || undefined);
       setValue("score", initialData.score.toString());
       setValue("time", initialData.time.toString());
       setValue("servings", initialData.servings);
@@ -123,6 +125,8 @@ export const useRecipeForm = (initialData?: Recipe) => {
   // Función para resetear el formulario
   const resetForm = () => {
     reset();
+    setThumbnailFile(null);
+    setExistingThumbnailUrl(undefined);
     setSelectedCategory(defaultCategory);
     setSelectedOrigin(defaultOrigin);
     setIngredients([{ id: "0", quantity: "" }]);
@@ -132,6 +136,9 @@ export const useRecipeForm = (initialData?: Recipe) => {
     ...form,
     watch,
     resetForm,
+    thumbnailFile,
+    setThumbnailFile,
+    existingThumbnailUrl,
     selectedCategory,
     setSelectedCategory,
     selectedOrigin,

--- a/src/shared/components/ui/ImageUpload/ImageUpload.tsx
+++ b/src/shared/components/ui/ImageUpload/ImageUpload.tsx
@@ -1,0 +1,191 @@
+import { useRef, useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  FormErrorMessage,
+  Icon,
+  Image,
+  Input,
+  Text,
+  VStack,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { FaImage, FaTrash, FaUndo, FaUpload } from "react-icons/fa";
+
+import { ImageUploadProps } from "./types";
+
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+const ImageUpload = ({
+  value,
+  onChange,
+  existingUrl,
+  error,
+}: ImageUploadProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [isCleared, setIsCleared] = useState(false);
+
+  useEffect(() => {
+    if (!value) {
+      setPreviewUrl(null);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(value);
+    setPreviewUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [value]);
+
+  useEffect(() => {
+    setIsCleared(false);
+  }, [existingUrl]);
+
+  const borderColor = useColorModeValue("gray.300", "gray.600");
+  const hoverBorderColor = useColorModeValue("teal.400", "teal.300");
+  const bgColor = useColorModeValue("gray.50", "gray.700");
+  const textColor = useColorModeValue("gray.500", "gray.400");
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) return;
+
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      setValidationError(
+        "Solo se permiten imágenes en formato JPG, PNG o WebP",
+      );
+      e.target.value = "";
+      return;
+    }
+
+    if (file.size > MAX_SIZE_BYTES) {
+      setValidationError("El archivo no puede superar los 5 MB");
+      e.target.value = "";
+      return;
+    }
+
+    setValidationError(null);
+    setIsCleared(false);
+    onChange(file);
+  };
+
+  // Deshace la selección del archivo nuevo y vuelve a mostrar la imagen existente
+  const handleUndo = () => {
+    onChange(null);
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  // Quita la imagen por completo (nueva o existente)
+  const handleRemove = () => {
+    onChange(null);
+    setValidationError(null);
+    setIsCleared(true);
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const displayUrl = isCleared ? null : (previewUrl ?? existingUrl ?? null);
+  const showUndo = !!previewUrl && !!existingUrl;
+  const combinedError = validationError ?? error;
+
+  return (
+    <VStack align="stretch" spacing={2}>
+      <Input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPTED_TYPES.join(",")}
+        display="none"
+        onChange={handleFileChange}
+      />
+
+      {displayUrl ? (
+        <Box position="relative" borderRadius="md" overflow="hidden">
+          <Image
+            src={displayUrl}
+            alt="Vista previa"
+            w="100%"
+            maxH="220px"
+            objectFit="cover"
+            borderRadius="md"
+          />
+          <Box position="absolute" bottom={2} right={2} display="flex" gap={2}>
+            <Button
+              size="sm"
+              leftIcon={<Icon as={FaUpload} />}
+              onClick={() => inputRef.current?.click()}
+              colorScheme="teal"
+              variant="solid"
+            >
+              Cambiar
+            </Button>
+            {showUndo && (
+              <Button
+                size="sm"
+                leftIcon={<Icon as={FaUndo} />}
+                onClick={handleUndo}
+                colorScheme="red"
+                variant="solid"
+              >
+                Deshacer
+              </Button>
+            )}
+            <Button
+              size="sm"
+              leftIcon={<Icon as={FaTrash} />}
+              onClick={handleRemove}
+              colorScheme="red"
+              variant="solid"
+            >
+              Quitar
+            </Button>
+          </Box>
+        </Box>
+      ) : (
+        <VStack align="stretch" spacing={2}>
+          <Box
+            border="2px dashed"
+            borderColor={combinedError ? "red.400" : borderColor}
+            borderRadius="md"
+            bg={bgColor}
+            p={6}
+            textAlign="center"
+            cursor="pointer"
+            transition="border-color 0.2s"
+            _hover={{
+              borderColor: combinedError ? "red.400" : hoverBorderColor,
+            }}
+            onClick={() => inputRef.current?.click()}
+          >
+            <VStack spacing={2}>
+              <Icon as={FaImage} boxSize={8} color={textColor} />
+              <Text fontSize="sm" color={textColor}>
+                Click para seleccionar una imagen
+              </Text>
+              <Text fontSize="xs" color={textColor}>
+                Máximo 5 MB
+              </Text>
+            </VStack>
+          </Box>
+          {isCleared && existingUrl && (
+            <Button
+              size="sm"
+              leftIcon={<Icon as={FaUndo} />}
+              onClick={() => setIsCleared(false)}
+              colorScheme="gray"
+              variant="outline"
+              alignSelf="flex-end"
+            >
+              Restaurar imagen
+            </Button>
+          )}
+        </VStack>
+      )}
+
+      {combinedError && (
+        <FormErrorMessage display="block">{combinedError}</FormErrorMessage>
+      )}
+    </VStack>
+  );
+};
+
+export default ImageUpload;

--- a/src/shared/components/ui/ImageUpload/index.ts
+++ b/src/shared/components/ui/ImageUpload/index.ts
@@ -1,0 +1,2 @@
+export { default as ImageUpload } from "./ImageUpload";
+export type { ImageUploadProps } from "./types";

--- a/src/shared/components/ui/ImageUpload/types.ts
+++ b/src/shared/components/ui/ImageUpload/types.ts
@@ -1,0 +1,6 @@
+export interface ImageUploadProps {
+  value: File | null;
+  onChange: (file: File | null) => void;
+  existingUrl?: string;
+  error?: string;
+}

--- a/src/shared/hooks/axiosFetch.ts
+++ b/src/shared/hooks/axiosFetch.ts
@@ -14,7 +14,10 @@ const useAxios = <T>() => {
 
   const axiosFetch = useCallback(
     async (method: keyof typeof HTTP_METHODS, url: string, body?: any) => {
-      const requestKey = `${method}-${url}-${JSON.stringify(body || {})}`;
+      const isFormData = body instanceof FormData;
+      const requestKey = isFormData
+        ? `${method}-${url}`
+        : `${method}-${url}-${JSON.stringify(body || {})}`;
 
       if (requestInProgressRef.current[requestKey]) {
         return;


### PR DESCRIPTION
### 📋 Resumen

Se incorpora la posibilidad de subir una imagen al crear o editar una receta.

Las imágenes se almacenan en Cloudinary a través del backend. El campo `thumbnail` del formulario pasa de ser un input de URL de texto a un componente de carga de archivos con preview visual.

**Cambios principales:**
- Nuevo componente `ImageUpload` con preview, validación client-side (JPG/PNG/WebP, máx. 5 MB) y gestión de estados: cambiar, deshacer, quitar y restaurar imagen anterior
- El hook `useAxios` ahora soporta `FormData` como body (antes solo JSON)
- Los endpoints `POST /recipe` y `PATCH /recipe/:id` ahora se envían como `multipart/form-data`, con `ingredients` y `steps` serializados como JSON string
- El campo `steps` pasa a ser obligatorio, alineado con la validación del backend

---

### 🧩 Tipo de cambio

- [X] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #67

---

### 🗒️ Notas adicionales

- No se establece `Content-Type` manualmente en las peticiones multipart — `axios` lo resuelve automáticamente con el boundary correspondiente.
- Los errores del backend relacionados con el archivo (tamaño y formato) se muestran en el toast de error usando el campo `details` de la respuesta.

---