### PR TITLE
Feature: User avatar management (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the `MisRegistros-Front` project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-05-23
+
+### Added
+
+- **User profile picture management**: Full avatar upload and deletion flow for authenticated users
+  - `AvatarUpload` component embedded in the profile modal: circular avatar with an overlay camera button to select a new image and a "Eliminar foto" link when a photo exists
+  - Client-side validation before upload: accepted formats (JPG, PNG, WebP) and 5 MB size limit, with toast feedback on error
+  - `useAvatarManagement` hook encapsulating `PATCH /v1/user/me/avatar` (multipart/form-data) and `DELETE /v1/user/me/avatar` calls; updates auth context on success
+  - `updateUser` function added to `AuthContext` and exposed via `useAuth`, allowing any component to update the persisted user state without re-login
+  - `avatar: string | null` field added to the `User` type, aligned with the updated backend model (`null` for users without a photo)
+- **Live avatar in Header**: The user menu avatar now renders the profile picture URL when available, falling back to name-based initials
+
 ## [2.2.0] - 2026-05-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "misregistros-front",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "misregistros-front",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misregistros-front",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/auth/components/AvatarUpload.tsx
+++ b/src/features/auth/components/AvatarUpload.tsx
@@ -1,0 +1,123 @@
+import { useRef } from "react";
+import {
+  Avatar,
+  Box,
+  Button,
+  IconButton,
+  Input,
+  Spinner,
+  VStack,
+  useToast,
+} from "@chakra-ui/react";
+import { FiCamera, FiTrash2 } from "react-icons/fi";
+
+import { useAuth } from "../hooks/useAuth";
+import { useAvatarManagement } from "../hooks/useAvatarManagement";
+
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+function AvatarUpload() {
+  const { user } = useAuth();
+  const { uploading, deleting, uploadAvatar, deleteAvatar } =
+    useAvatarManagement();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
+
+  const isLoading = uploading || deleting;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      toast({
+        status: "error",
+        description: "Solo se permiten imágenes en formato JPG, PNG o WebP",
+        isClosable: true,
+      });
+      return;
+    }
+
+    if (file.size > MAX_SIZE_BYTES) {
+      toast({
+        status: "error",
+        description: "El archivo no puede superar los 5 MB",
+        isClosable: true,
+      });
+      return;
+    }
+
+    const result = await uploadAvatar(file);
+    toast({
+      status: result.success ? "success" : "error",
+      description: result.success
+        ? "Foto de perfil actualizada"
+        : (result.message ?? "Error al subir la foto"),
+      isClosable: true,
+    });
+  };
+
+  const handleDelete = async () => {
+    const result = await deleteAvatar();
+    toast({
+      status: result.success ? "success" : "error",
+      description: result.success
+        ? "Foto de perfil eliminada"
+        : (result.message ?? "Error al eliminar la foto"),
+      isClosable: true,
+    });
+  };
+
+  if (!user) return null;
+
+  return (
+    <VStack spacing={2}>
+      <Box position="relative" display="inline-block">
+        <Avatar
+          src={user.avatar ?? undefined}
+          name={user.username}
+          size="xl"
+          backgroundColor="green.800"
+          color="green.50"
+        />
+        <IconButton
+          aria-label="Cambiar foto de perfil"
+          icon={uploading ? <Spinner size="xs" /> : <FiCamera />}
+          size="xs"
+          borderRadius="full"
+          position="absolute"
+          bottom={0}
+          right={0}
+          onClick={() => inputRef.current?.click()}
+          isDisabled={isLoading}
+          _hover={{ bg: "gray.600" }}
+        />
+        <Input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED_TYPES.join(",")}
+          display="none"
+          onChange={handleFileChange}
+        />
+      </Box>
+
+      {user.avatar && (
+        <Button
+          variant="link"
+          size="xs"
+          color="red.400"
+          leftIcon={<FiTrash2 />}
+          onClick={handleDelete}
+          isLoading={deleting}
+          isDisabled={uploading}
+        >
+          Eliminar foto
+        </Button>
+      )}
+    </VStack>
+  );
+}
+
+export default AvatarUpload;

--- a/src/features/auth/components/ProfileModal.tsx
+++ b/src/features/auth/components/ProfileModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import {
-  Avatar,
   Badge,
   Divider,
   Flex,
@@ -23,6 +22,7 @@ import useAxios from "../../../shared/hooks/axiosFetch";
 import { API_BASE_URL } from "../../../shared/constants/environment";
 import { HTTP_METHODS } from "../../../shared/constants/httpMethods";
 import { User } from "../types";
+import AvatarUpload from "./AvatarUpload";
 
 type Props = {
   isOpen: boolean;
@@ -71,12 +71,7 @@ function ProfileModal({ isOpen, onClose }: Props) {
           ) : (
             <VStack spacing={5} align="stretch">
               <Flex justify="center">
-                <Avatar
-                  name={profile.username}
-                  size="xl"
-                  backgroundColor="green.800"
-                  color="green.50"
-                />
+                <AvatarUpload />
               </Flex>
 
               <VStack spacing={1} align="center">

--- a/src/features/auth/context/AuthContext.tsx
+++ b/src/features/auth/context/AuthContext.tsx
@@ -11,6 +11,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   login: (token: string, user: User) => void;
   logout: () => void;
+  updateUser: (user: User) => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(
@@ -40,9 +41,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     localStorage.removeItem(AUTH_USER_KEY);
   };
 
+  const updateUser = (updatedUser: User) => {
+    setUser(updatedUser);
+    localStorage.setItem(AUTH_USER_KEY, JSON.stringify(updatedUser));
+  };
+
   return (
     <AuthContext.Provider
-      value={{ user, token, isAuthenticated: !!token && !!user, login, logout }}
+      value={{ user, token, isAuthenticated: !!token && !!user, login, logout, updateUser }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/features/auth/hooks/useAvatarManagement.ts
+++ b/src/features/auth/hooks/useAvatarManagement.ts
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import axios, { AxiosError } from "axios";
+
+import { useAuth } from "./useAuth";
+import { User } from "../types";
+import { API_BASE_URL, API_KEY } from "../../../shared/constants/environment";
+
+interface AvatarResult {
+  success: boolean;
+  message?: string;
+}
+
+interface BackendError {
+  details: string;
+}
+
+export function useAvatarManagement() {
+  const { token, updateUser } = useAuth();
+  const [uploading, setUploading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const authHeaders = {
+    "api-key": API_KEY,
+    ...(token && { Authorization: `Bearer ${token}` }),
+  };
+
+  const uploadAvatar = async (file: File): Promise<AvatarResult> => {
+    setUploading(true);
+    const formData = new FormData();
+    formData.append("avatar", file);
+    try {
+      const { data } = await axios.patch<{ data: User }>(
+        `${API_BASE_URL}/user/me/avatar`,
+        formData,
+        { headers: authHeaders },
+      );
+      updateUser(data.data);
+      return { success: true };
+    } catch (err) {
+      const axiosErr = err as AxiosError<BackendError>;
+      return {
+        success: false,
+        message: axiosErr.response?.data?.details,
+      };
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const deleteAvatar = async (): Promise<AvatarResult> => {
+    setDeleting(true);
+    try {
+      const { data } = await axios.delete<{ data: User }>(
+        `${API_BASE_URL}/user/me/avatar`,
+        { headers: authHeaders },
+      );
+      updateUser(data.data);
+      return { success: true };
+    } catch (err) {
+      const axiosErr = err as AxiosError<BackendError>;
+      return {
+        success: false,
+        message: axiosErr.response?.data?.details,
+      };
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return { uploading, deleting, uploadAvatar, deleteAvatar };
+}

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   isActive: boolean;
   lastLoginAt: string | null;
   createdAt: string;
+  avatar: string | null;
 }
 
 export interface LoginPayload {

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -69,6 +69,7 @@ function Header() {
             <Menu>
               <MenuButton>
                 <Avatar
+                  src={user.avatar ?? undefined}
                   name={user.username}
                   backgroundColor="green.800"
                   color="green.50"


### PR DESCRIPTION
### 📋 Resumen

Implementa la gestión de "Foto de Perfil" para usuarios autenticados. Los usuarios pueden subir o reemplazar su avatar desde el modal de perfil, y también eliminarlo. El avatar se refleja en tiempo real en el header sin necesidad de re-login.

Se integran los endpoints `PATCH /v1/user/me/avatar` y `DELETE /v1/user/me/avatar` provistos por el backend, que almacenan la imagen en Cloudinary bajo `mis-registros/profile-pictures/`.

---

### 🧩 Tipo de cambio

- [X] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

**Issues**:
- #69
  - #70
  - #71

---

### 🗒️ Notas adicionales

- El campo `avatar: string | null` fue agregado al tipo `User` alineado con el modelo actualizado del backend. Los usuarios existentes sin foto tendrán `null` como valor inicial.
- La validación de formato (`.jpg`, `.png`, `.webp`) y tamaño máximo (5 MB) se realiza en el cliente antes de enviar al backend.
- `updateUser` fue incorporado a `AuthContext` para permitir actualizar el estado del usuario persistido sin requerir re-login; puede reutilizarse en futuros features que modifiquen datos del perfil.

---