### PR TITLE
Fix: Visual enchancements and Micro-interactions (#73)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^7.2.0",
         "@typescript-eslint/parser": "^7.2.0",
         "@vitejs/plugin-react": "^4.2.1",
+        "baseline-browser-mapping": "^2.10.32",
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
@@ -3102,13 +3103,16 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.9.tgz",
-      "integrity": "sha512-hY/u2lxLrbecMEWSB0IpGzGyDyeoMFQhCvZd2jGFSE5I17Fh01sYUBPCJtkWERw7zrac9+cIghxm/ytJa2X8iA==",
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "baseline-browser-mapping": "^2.10.32",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",

--- a/src/features/auth/components/ProfileModal.tsx
+++ b/src/features/auth/components/ProfileModal.tsx
@@ -15,6 +15,7 @@ import {
   SkeletonCircle,
   Text,
   VStack,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import { FiCalendar, FiClock, FiMail } from "react-icons/fi";
 
@@ -63,7 +64,9 @@ function ProfileModal({ isOpen, onClose }: Props) {
               </Flex>
               <Skeleton height="24px" mx="auto" w="40%" />
               <Skeleton height="16px" mx="auto" w="20%" />
-              <Divider />
+              <Divider
+                borderColor={useColorModeValue("green.700", "green.400")}
+              />
               <Skeleton height="16px" />
               <Skeleton height="16px" />
               <Skeleton height="16px" />
@@ -87,7 +90,9 @@ function ProfileModal({ isOpen, onClose }: Props) {
                 </Badge>
               </VStack>
 
-              <Divider />
+              <Divider
+                borderColor={useColorModeValue("green.700", "green.400")}
+              />
 
               <VStack spacing={3} align="stretch">
                 <HStack spacing={3}>

--- a/src/features/auth/pages/ForgotPasswordPage.tsx
+++ b/src/features/auth/pages/ForgotPasswordPage.tsx
@@ -50,8 +50,10 @@ const ForgotPasswordPage = () => {
       if (!response.ok) {
         const err = await response.json();
         const description = err.validations
-          ? err.validations.map((v: { message: string }) => v.message).join(", ")
-          : err.details ?? "Error al procesar la solicitud";
+          ? err.validations
+              .map((v: { message: string }) => v.message)
+              .join(", ")
+          : (err.details ?? "Error al procesar la solicitud");
         throw new Error(description);
       }
 
@@ -89,18 +91,22 @@ const ForgotPasswordPage = () => {
                   Si existe una cuenta con ese email, recibirás un link para
                   restablecer tu contraseña en los próximos minutos.
                 </Text>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setSubmitted(false)}
-                >
-                  ¿No recibiste el correo? Intentar de nuevo
-                </Button>
+                <Text fontSize="sm">
+                  ¿No recibiste el correo?{" "}
+                  <Link
+                    as={RouterLink}
+                    to="/login"
+                    variant="loginFlow"
+                    onClick={() => setSubmitted(false)}
+                  >
+                    Intentar de nuevo
+                  </Link>
+                </Text>
               </>
             ) : (
               <>
                 <Heading size="lg">Recuperar contraseña</Heading>
-                <Text fontSize="sm" color="gray.400" textAlign="center">
+                <Text fontSize="sm" color="gray.600" textAlign="center">
                   Ingresa tu email y te enviaremos un link para recuperar tu
                   contraseña.
                 </Text>
@@ -122,7 +128,7 @@ const ForgotPasswordPage = () => {
                     <Button
                       type="submit"
                       w="full"
-                      colorScheme="green"
+                      variant={"greenButton"}
                       isLoading={isSubmitting}
                     >
                       Enviar link de recuperación
@@ -132,7 +138,7 @@ const ForgotPasswordPage = () => {
               </>
             )}
 
-            <Link as={RouterLink} to="/login" color="green.400" fontSize="sm">
+            <Link as={RouterLink} to="/login" variant="loginFlow">
               Volver al inicio de sesión
             </Link>
           </VStack>

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -46,7 +46,10 @@ const LoginPage = () => {
         description: state.successToast.description,
         status: "success",
       });
-      navigate(location.pathname, { replace: true, state: { from: state.from } });
+      navigate(location.pathname, {
+        replace: true,
+        state: { from: state.from },
+      });
     }
   }, []);
 
@@ -128,7 +131,7 @@ const LoginPage = () => {
                 <Button
                   type="submit"
                   w="full"
-                  colorScheme="green"
+                  variant="greenButton"
                   isLoading={isSubmitting}
                 >
                   Iniciar sesión
@@ -138,16 +141,11 @@ const LoginPage = () => {
             <VStack spacing={1}>
               <Text fontSize="sm">
                 ¿No tienes cuenta?{" "}
-                <Link as={RouterLink} to="/register" color="green.400">
+                <Link as={RouterLink} to="/register" variant="loginFlow">
                   Regístrate
                 </Link>
               </Text>
-              <Link
-                as={RouterLink}
-                to="/forgot-password"
-                color="gray.400"
-                fontSize="sm"
-              >
+              <Link as={RouterLink} to="/forgot-password" variant="loginFlow">
                 ¿Olvidaste tu contraseña?
               </Link>
             </VStack>

--- a/src/features/auth/pages/RegisterPage.tsx
+++ b/src/features/auth/pages/RegisterPage.tsx
@@ -48,7 +48,9 @@ const RegisterPage = () => {
       if (!response.ok) {
         const err = await response.json();
         const description = err.validations
-          ? err.validations.map((v: { message: string }) => v.message).join(", ")
+          ? err.validations
+              .map((v: { message: string }) => v.message)
+              .join(", ")
           : (err.details ?? "Error al registrar usuario");
         throw new Error(description);
       }
@@ -127,7 +129,7 @@ const RegisterPage = () => {
                 <Button
                   type="submit"
                   w="full"
-                  colorScheme="green"
+                  variant="greenButton"
                   isLoading={isSubmitting}
                 >
                   Crear cuenta
@@ -136,7 +138,7 @@ const RegisterPage = () => {
             </Box>
             <Text fontSize="sm">
               ¿Ya tienes cuenta?{" "}
-              <Link as={RouterLink} to="/login" color="green.400">
+              <Link as={RouterLink} to="/login" variant="loginFlow">
                 Iniciar sesión
               </Link>
             </Text>

--- a/src/features/auth/pages/ResetPasswordPage.tsx
+++ b/src/features/auth/pages/ResetPasswordPage.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useSearchParams, useNavigate, Link as RouterLink } from "react-router-dom";
+import {
+  useSearchParams,
+  useNavigate,
+  Link as RouterLink,
+} from "react-router-dom";
 import {
   Box,
   Button,
@@ -101,7 +105,12 @@ const ResetPasswordPage = () => {
       <Text fontSize="sm" color="red.400" textAlign="center">
         {message}
       </Text>
-      <Link as={RouterLink} to="/forgot-password" color="green.400" fontSize="sm">
+      <Link
+        as={RouterLink}
+        to="/forgot-password"
+        color="green.400"
+        fontSize="sm"
+      >
         Solicitar un nuevo correo
       </Link>
     </VStack>
@@ -167,7 +176,7 @@ const ResetPasswordPage = () => {
                     <Button
                       type="submit"
                       w="full"
-                      colorScheme="green"
+                      variant="greenButton"
                       isLoading={isSubmitting}
                     >
                       Restablecer contraseña
@@ -177,7 +186,7 @@ const ResetPasswordPage = () => {
               </>
             )}
 
-            <Link as={RouterLink} to="/login" color="green.400" fontSize="sm">
+            <Link as={RouterLink} to="/login" variant="loginFlow">
               Volver al inicio de sesión
             </Link>
           </VStack>

--- a/src/features/recipe-book/components/Card.tsx
+++ b/src/features/recipe-book/components/Card.tsx
@@ -6,8 +6,8 @@ import {
   CardFooter,
   Flex,
   Heading,
-  HStack,
   Text,
+  Tooltip,
 } from "@chakra-ui/react";
 import { FaKitchenSet } from "react-icons/fa6";
 
@@ -43,15 +43,19 @@ function RecipeCard({ recipe }: Props) {
       </CardBody>
       <CardFooter pt="0">
         <Flex width="100%" justifyContent="space-between" alignItems="center">
-          <Button
-            variant="greenButton"
-            onClick={() => navigate(`/recipes/${recipe.id}`)}
+          <Tooltip
+            openDelay={500}
+            label="Preparar receta"
+            hasArrow
+            placement="top"
           >
-            <HStack spacing={2}>
+            <Button
+              variant="greenButton"
+              onClick={() => navigate(`/recipes/${recipe.id}`)}
+            >
               <FaKitchenSet size={20} />
-              <Text variant="buttonText">Preparar</Text>
-            </HStack>
-          </Button>
+            </Button>
+          </Tooltip>
 
           <RecipeTags tags={cardTags} size="md" />
         </Flex>

--- a/src/features/recipe-book/components/Modal.tsx
+++ b/src/features/recipe-book/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Button,
@@ -7,10 +7,17 @@ import {
   ModalFooter,
   ModalOverlay,
   Spacer,
+  Tooltip,
   useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
-import { FaCopy, FaPencilAlt, FaThumbtack, FaTrash } from "react-icons/fa";
+import {
+  FaCopy,
+  FaPenToSquare,
+  FaThumbtack,
+  FaXmark,
+  FaTrash,
+} from "react-icons/fa6";
 
 import RecipeModalSkeleton from "./ModalSkeleton";
 import RecipeModalContent from "./ModalContent";
@@ -39,6 +46,7 @@ function RecipeModal({ isOpen, onClose, loading, data }: Props) {
   } = useDisclosure();
 
   const [isUnlocked, setIsUnlocked] = useState(true);
+  const initialFocusRef = useRef<HTMLSpanElement>(null);
 
   const iconColor = useColorModeValue("#1A202C", "white");
   const pinUnlockedBg = useColorModeValue("gray.300", "#3C4658");
@@ -71,6 +79,7 @@ function RecipeModal({ isOpen, onClose, loading, data }: Props) {
         closeOnOverlayClick={isUnlocked}
         isOpen={isOpen}
         onClose={onClose}
+        initialFocusRef={initialFocusRef}
       >
         <ModalOverlay />
         <ModalContent>
@@ -79,57 +88,95 @@ function RecipeModal({ isOpen, onClose, loading, data }: Props) {
           ) : (
             data && <RecipeModalContent data={data} />
           )}
-          <ModalFooter mt={4}>
+          <span
+            ref={initialFocusRef}
+            tabIndex={-1}
+            style={{ outline: "none" }}
+          />
+          <ModalFooter
+            backgroundColor={useColorModeValue("gray.200", "#232B3A")}
+          >
             {canManage && (
-              <Button
-                isDisabled={!isUnlocked}
-                variant="deleteButton"
-                onClick={onOpenDeleteConfirmation}
+              <Tooltip
+                openDelay={500}
+                label="Eliminar receta"
+                hasArrow
+                placement="top"
               >
-                <FaTrash color={iconColor} />
-              </Button>
+                <Button
+                  isDisabled={!isUnlocked}
+                  variant="deleteButton"
+                  onClick={onOpenDeleteConfirmation}
+                >
+                  <FaTrash color={iconColor} />
+                </Button>
+              </Tooltip>
             )}
 
             <Spacer />
 
-            <Button
-              isDisabled={isDuplicating}
-              variant="copyButton"
-              onClick={handleDuplicate}
-              isLoading={isDuplicating}
+            <Tooltip
+              openDelay={500}
+              label="Duplicar receta"
+              hasArrow
+              placement="top"
             >
-              <FaCopy color={iconColor} />
-            </Button>
+              <Button
+                // isDisabled={!isUnlocked} // TODO: Enable with fix
+                isDisabled={true}
+                variant="copyButton"
+                onClick={handleDuplicate}
+                isLoading={isDuplicating}
+              >
+                <FaCopy color={iconColor} />
+              </Button>
+            </Tooltip>
 
             {canManage && (
+              <Tooltip
+                openDelay={500}
+                label="Editar receta"
+                hasArrow
+                placement="top"
+              >
+                <Button
+                  ml={4}
+                  isDisabled={!isUnlocked}
+                  variant="editButton"
+                  onClick={handleEdit}
+                >
+                  <FaPenToSquare color={iconColor} />
+                </Button>
+              </Tooltip>
+            )}
+
+            {canManage && (
+              <Tooltip
+                openDelay={500}
+                label={isUnlocked ? "Fijar tarjeta" : "Liberar tarjeta"}
+                hasArrow
+                placement="top"
+              >
+                <Button
+                  mx={4}
+                  backgroundColor={isUnlocked ? pinUnlockedBg : pinLockedBg}
+                  _hover={isUnlocked ? pinUnlockedHover : pinLockedHover}
+                  onClick={() => setIsUnlocked(!isUnlocked)}
+                >
+                  <FaThumbtack size={16} color={iconColor} />
+                </Button>
+              </Tooltip>
+            )}
+
+            <Tooltip openDelay={500} label="Cerrar" hasArrow placement="top">
               <Button
-                ml={4}
                 isDisabled={!isUnlocked}
-                variant="editButton"
-                onClick={handleEdit}
+                onClick={onClose}
+                variant="redButton"
               >
-                <FaPencilAlt color={iconColor} />
+                <FaXmark size={16} color={iconColor} />
               </Button>
-            )}
-
-            {canManage && (
-              <Button
-                mx={4}
-                backgroundColor={isUnlocked ? pinUnlockedBg : pinLockedBg}
-                _hover={isUnlocked ? pinUnlockedHover : pinLockedHover}
-                onClick={() => setIsUnlocked(!isUnlocked)}
-              >
-                <FaThumbtack size={16} color={iconColor} />
-              </Button>
-            )}
-
-            <Button
-              isDisabled={!isUnlocked}
-              onClick={onClose}
-              variant="greenButton"
-            >
-              Cerrar
-            </Button>
+            </Tooltip>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/features/recipe-book/components/RecipeList/ActionButtons.tsx
+++ b/src/features/recipe-book/components/RecipeList/ActionButtons.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
-import { HStack, Button } from "@chakra-ui/react";
-import { FaCog, FaPlusSquare } from "react-icons/fa";
+import { HStack, IconButton, Tooltip } from "@chakra-ui/react";
+import { FaGear, FaPlus } from "react-icons/fa6";
 
 interface ActionButtonsProps {
   onNavigateToMeta: () => void;
@@ -10,26 +10,41 @@ interface ActionButtonsProps {
 const ActionButtons = memo(
   ({ onNavigateToMeta, onOpenRecipeCreate }: ActionButtonsProps) => {
     return (
-      <HStack mt={4} mb={8} gap={4}>
-        <Button
-          leftIcon={<FaCog />}
-          onClick={onNavigateToMeta}
-          variant="greenButton"
+      <HStack mb={8} gap={4}>
+        <Tooltip
+          openDelay={500}
+          hasArrow
+          placement="top"
+          label="Crear receta"
+          aria-label="Create Recipe"
         >
-          Administrar
-        </Button>
+          <IconButton
+            px={4}
+            aria-label="Create Recipe"
+            icon={<FaPlus />}
+            variant="greenButton"
+            onClick={onOpenRecipeCreate}
+          />
+        </Tooltip>
 
-        <Button
-          leftIcon={<FaPlusSquare />}
-          variant="greenButton"
-          ml="2"
-          onClick={onOpenRecipeCreate}
+        <Tooltip
+          openDelay={500}
+          hasArrow
+          placement="top"
+          label="Administrar listas"
+          aria-label="Manage Lists"
         >
-          Crear Receta
-        </Button>
+          <IconButton
+            px={4}
+            aria-label="Manage Lists"
+            icon={<FaGear />}
+            onClick={onNavigateToMeta}
+            variant="greenButton"
+          />
+        </Tooltip>
       </HStack>
     );
-  }
+  },
 );
 
 ActionButtons.displayName = "ActionButtons";

--- a/src/features/recipe-book/components/RecipeList/RecipeGrid.tsx
+++ b/src/features/recipe-book/components/RecipeList/RecipeGrid.tsx
@@ -22,7 +22,7 @@ const RecipeGrid = memo(
           recipes?.map((recipe) => (
             <Box
               key={recipe.id}
-              onDoubleClick={() => onRecipeClick(recipe)}
+              onClick={() => onRecipeClick(recipe)}
               cursor="pointer"
               transition="transform 0.2s"
               _hover={{ transform: "scale(1.02)" }}

--- a/src/features/recipe-book/components/RecipeList/SearchFilters.tsx
+++ b/src/features/recipe-book/components/RecipeList/SearchFilters.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { useForm } from "react-hook-form";
 import {
+  Box,
   HStack,
   Input,
   InputGroup,
@@ -11,12 +12,12 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 import {
-  FaSearch,
-  FaSortAlphaDown,
-  FaSortAlphaDownAlt,
-  FaTimes,
+  FaMagnifyingGlass,
+  FaArrowDownAZ,
+  FaArrowDownZA,
+  FaXmark,
   FaUser,
-} from "react-icons/fa";
+} from "react-icons/fa6";
 
 import { Category, Origin } from "../../types";
 import { SearchForm } from "../../../../shared/types/searchForm";
@@ -99,7 +100,7 @@ const SearchFilters = memo(
     };
 
     return (
-      <HStack mt="4" mb="8" gap="25px">
+      <HStack mb={8} gap={6}>
         <form onSubmit={handleSubmit(handleSearchSubmit)}>
           <InputGroup
             _hover={{
@@ -121,7 +122,16 @@ const SearchFilters = memo(
               cursor="pointer"
               onClick={handleIconClick}
             >
-              <FaSearch />
+              <Tooltip
+                openDelay={500}
+                label="Buscar receta"
+                hasArrow
+                placement="top"
+              >
+                <Box display="flex">
+                  <FaMagnifyingGlass />
+                </Box>
+              </Tooltip>
             </InputLeftElement>
             <Input
               type="text"
@@ -190,6 +200,7 @@ const SearchFilters = memo(
         </Select>
 
         <Tooltip
+          openDelay={500}
           hasArrow
           placement="top"
           label={sortDirection === "asc" ? "Ascendente" : "Descendente"}
@@ -211,12 +222,12 @@ const SearchFilters = memo(
             borderWidth={2}
             icon={
               sortDirection === "asc" ? (
-                <FaSortAlphaDown
+                <FaArrowDownAZ
                   size={24}
                   color={useColorModeValue("#48BB78", "#38A169")}
                 />
               ) : (
-                <FaSortAlphaDownAlt
+                <FaArrowDownZA
                   size={24}
                   color={useColorModeValue("#2F855A", "#9AE6B4")}
                 />
@@ -230,9 +241,12 @@ const SearchFilters = memo(
         </Tooltip>
 
         <Tooltip
+          openDelay={500}
           hasArrow
           placement="top"
-          label="Mostrar solo mis recetas"
+          label={
+            onlyMine ? "Mostrar todas las recetas" : "Mostrar solo mis recetas"
+          }
           aria-label="My recipes tooltip"
         >
           <IconButton
@@ -264,6 +278,7 @@ const SearchFilters = memo(
         </Tooltip>
 
         <Tooltip
+          openDelay={500}
           hasArrow
           placement="top"
           label="Limpiar filtros"
@@ -271,7 +286,7 @@ const SearchFilters = memo(
         >
           <IconButton
             aria-label="Clean filters"
-            icon={<FaTimes size={16} />}
+            icon={<FaXmark size={16} />}
             variant="deleteButtonOutline"
             isDisabled={!hasActiveFilters}
             onClick={handleClearFilters}

--- a/src/features/recipe-book/components/RecipeList/SearchFilters.tsx
+++ b/src/features/recipe-book/components/RecipeList/SearchFilters.tsx
@@ -193,7 +193,6 @@ const SearchFilters = memo(
           variant={sortBy === "" ? "" : "selected"}
           onChange={(e) => onSortChange(e.target.value)}
         >
-          <option value="id">Id</option>
           <option value="name">Nombre</option>
           <option value="score">Mejor Valoradas</option>
           <option value="createdAt">Fecha Creación</option>

--- a/src/features/recipe-book/pages/Create.tsx
+++ b/src/features/recipe-book/pages/Create.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { Box, Heading, Flex, useToast } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { FaFloppyDisk } from "react-icons/fa6";
 
 import {
   RecipeForm,
@@ -180,9 +181,8 @@ const CreateRecipePage = () => {
       <Flex justify="space-between" align="center" mb={6}>
         <Heading size="lg">{pageTitle}</Heading>
         <RecipeFormButtons
-          submitButtonText={
-            location.state?.isDuplicate ? "Guardar Copia" : "Guardar Receta"
-          }
+          submitIcon={<FaFloppyDisk />}
+          submitTooltip={location.state?.isDuplicate ? "Guardar copia" : "Guardar receta"}
           cancelAction={() => navigate("/recipes")}
         />
       </Flex>

--- a/src/features/recipe-book/pages/Meta.tsx
+++ b/src/features/recipe-book/pages/Meta.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -17,6 +18,7 @@ import {
   Grid,
   GridItem,
   Heading,
+  IconButton,
   Input,
   Modal,
   ModalBody,
@@ -29,22 +31,26 @@ import {
   Spacer,
   Table,
   TableContainer,
+  Tag,
   Tbody,
   Td,
   Text,
   Th,
   Thead,
+  Tooltip,
   Tr,
   useColorModeValue,
   useDisclosure,
   useToast,
 } from "@chakra-ui/react";
-import { FaPencilAlt, FaTrash } from "react-icons/fa";
+
+import { FaPenToSquare, FaTrash } from "react-icons/fa6";
 
 import useAxios from "../../../shared/hooks/axiosFetch";
 
 import { API_BASE_URL } from "../../../shared/constants/environment";
 import { HTTP_METHODS } from "../../../shared/constants/httpMethods";
+import { FaArrowLeft, FaPlus } from "react-icons/fa6";
 
 const MESSAGES = {
   ERROR: {
@@ -275,8 +281,8 @@ const DataTable = React.memo<{
         {type === "ingredient"
           ? MESSAGES.LOADING.INGREDIENTS
           : type === "category"
-          ? MESSAGES.LOADING.CATEGORIES
-          : MESSAGES.LOADING.ORIGINS}
+            ? MESSAGES.LOADING.CATEGORIES
+            : MESSAGES.LOADING.ORIGINS}
       </Text>
     );
   }
@@ -287,8 +293,8 @@ const DataTable = React.memo<{
         {type === "ingredient"
           ? MESSAGES.NOT_FOUND.INGREDIENTS
           : type === "category"
-          ? MESSAGES.NOT_FOUND.CATEGORIES
-          : MESSAGES.NOT_FOUND.ORIGINS}
+            ? MESSAGES.NOT_FOUND.CATEGORIES
+            : MESSAGES.NOT_FOUND.ORIGINS}
       </Text>
     );
   }
@@ -311,11 +317,14 @@ const DataTable = React.memo<{
           <Tr>
             <Th>Nombre</Th>
             {type === "ingredient" && (
-              <Th width="100px" textAlign="center">
+              <Th width="50px" fontSize={10} textAlign="center">
                 Unidad
               </Th>
             )}
-            <Th width="100px" textAlign="center">
+            <Th width="50px" textAlign="center">
+              Usos
+            </Th>
+            <Th width="50px" textAlign="center">
               Acción
             </Th>
           </Tr>
@@ -346,8 +355,6 @@ const TableRow = React.memo<{
   loadingCrud: boolean;
   iconColor: string;
 }>(({ item, type, onEdit, onDelete, loadingCrud, iconColor }) => {
-  const countTextColor = useColorModeValue("gray.500", "gray.400");
-
   const handleEdit = useCallback(() => {
     onEdit(item, type);
   }, [item, type, onEdit]);
@@ -360,31 +367,20 @@ const TableRow = React.memo<{
 
   return (
     <Tr>
-      <Td>
-        {item.name}{" "}
-        <Text
-          as="sub"
-          sx={{
-            color: countTextColor + " !important",
-            fontSize: "xs",
-          }}
-          fontWeight="normal"
-        >
-          ({usageCount})
-        </Text>
-      </Td>
+      <Td>{item.name}</Td>
       {type === "ingredient" && "unit" in item && (
         <Td textAlign="center">{item.unit}</Td>
       )}
+      <Td textAlign="center">{usageCount}</Td>
       <Td>
-        <Flex gap={2} justifyContent="right">
+        <Flex gap={2} justifyContent="center">
           <Button
             variant="editButton"
             size="sm"
             height="25px"
             onClick={handleEdit}
           >
-            <FaPencilAlt color={iconColor} />
+            <FaPenToSquare color={iconColor} />
           </Button>
           <Button
             variant="deleteButton"
@@ -402,6 +398,8 @@ const TableRow = React.memo<{
 });
 
 const RecipeMetaPage: React.FC = () => {
+  const navigate = useNavigate();
+
   const [categories, setCategories] = useState<Category[]>([]);
   const [origins, setOrigins] = useState<Origin[]>([]);
   const [ingredients, setIngredients] = useState<Ingredient[]>([]);
@@ -409,8 +407,6 @@ const RecipeMetaPage: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [currentItem, setCurrentItem] = useState<MetaDataItem | null>(null);
   const [currentType, setCurrentType] = useState<MetaDataType>("category");
-
-  const countTextColor = useColorModeValue("gray.500", "gray.400");
 
   const [itemUnit, setItemUnit] = useState("");
   const availableUnits = [
@@ -495,7 +491,7 @@ const RecipeMetaPage: React.FC = () => {
 
       onOpen();
     },
-    [onOpen]
+    [onOpen],
   );
 
   const handleEdit = useCallback(
@@ -511,7 +507,7 @@ const RecipeMetaPage: React.FC = () => {
 
       onOpen();
     },
-    [onOpen]
+    [onOpen],
   );
 
   const handleDelete = useCallback(
@@ -520,8 +516,8 @@ const RecipeMetaPage: React.FC = () => {
         type === "category"
           ? "category"
           : type === "origin"
-          ? "origin"
-          : "ingredient";
+            ? "origin"
+            : "ingredient";
 
       let itemName = "";
       if (type === "category") {
@@ -536,10 +532,10 @@ const RecipeMetaPage: React.FC = () => {
 
       await performCrudOperation(
         HTTP_METHODS.DELETE,
-        `${API_BASE_URL}/${endpoint}/${id}`
+        `${API_BASE_URL}/${endpoint}/${id}`,
       );
     },
-    [performCrudOperation, categories, origins, ingredients]
+    [performCrudOperation, categories, origins, ingredients],
   );
 
   const handleSave = async () => {
@@ -558,8 +554,8 @@ const RecipeMetaPage: React.FC = () => {
       currentType === "category"
         ? "category"
         : currentType === "origin"
-        ? "origin"
-        : "ingredient";
+          ? "origin"
+          : "ingredient";
     const method = isEditing ? HTTP_METHODS.PATCH : HTTP_METHODS.POST;
     const url = isEditing
       ? `${API_BASE_URL}/${endpoint}/${currentItem?.id}`
@@ -579,9 +575,20 @@ const RecipeMetaPage: React.FC = () => {
 
   return (
     <Box height="100%">
-      <Heading mb={4} size="lg">
-        Administrar
-      </Heading>
+      <Flex mb={4} justify="space-between" align="center">
+        <Heading size="lg">Administrar listas</Heading>
+
+        <Tooltip
+          openDelay={500}
+          label="Volver al recetario"
+          hasArrow
+          placement="top"
+        >
+          <Button onClick={() => navigate("/recipes")} variant="redButton">
+            <FaArrowLeft />
+          </Button>
+        </Tooltip>
+      </Flex>
 
       <Grid templateColumns="repeat(3, 1fr)" gap={6} height="calc(100% - 60px)">
         {/* Ingredientes */}
@@ -592,23 +599,24 @@ const RecipeMetaPage: React.FC = () => {
                 <Heading size="md" mx={2}>
                   Ingredientes
                 </Heading>
-                <Text
-                  as="sub"
-                  sx={{
-                    color: countTextColor + " !important",
-                    fontSize: "sm",
-                  }}
-                >
-                  ({ingredients.length})
-                </Text>
+                <Tag>{ingredients.length}</Tag>
                 <Spacer />
-                <Button
-                  variant="greenButton"
-                  onClick={() => handleAddNew("ingredient")}
-                  isLoading={loadingMetadata}
+                <Tooltip
+                  openDelay={500}
+                  hasArrow
+                  placement="top"
+                  label="Crear ingrediente"
+                  aria-label="Create Ingredient"
                 >
-                  Agregar
-                </Button>
+                  <IconButton
+                    px={4}
+                    aria-label="Create Ingredient"
+                    icon={<FaPlus />}
+                    variant="greenButton"
+                    onClick={() => handleAddNew("ingredient")}
+                    isLoading={loadingMetadata}
+                  />
+                </Tooltip>
               </Flex>
             </CardHeader>
             <CardBody overflowY="auto" height="calc(100% - 60px)" px={2}>
@@ -632,23 +640,24 @@ const RecipeMetaPage: React.FC = () => {
                 <Heading size="md" mx={2}>
                   Categorías
                 </Heading>
-                <Text
-                  as="sub"
-                  sx={{
-                    color: countTextColor + " !important",
-                    fontSize: "sm",
-                  }}
-                >
-                  ({categories.length})
-                </Text>
+                <Tag>{categories.length}</Tag>
                 <Spacer />
-                <Button
-                  variant="greenButton"
-                  onClick={() => handleAddNew("category")}
-                  isLoading={loadingMetadata}
+                <Tooltip
+                  openDelay={500}
+                  hasArrow
+                  placement="top"
+                  label="Crear categoría"
+                  aria-label="Create Category"
                 >
-                  Agregar
-                </Button>
+                  <IconButton
+                    px={4}
+                    aria-label="Create Category"
+                    icon={<FaPlus />}
+                    variant="greenButton"
+                    onClick={() => handleAddNew("category")}
+                    isLoading={loadingMetadata}
+                  />
+                </Tooltip>
               </Flex>
             </CardHeader>
             <CardBody overflowY="auto" height="calc(100% - 60px)" px={2}>
@@ -672,23 +681,24 @@ const RecipeMetaPage: React.FC = () => {
                 <Heading size="md" mx={2}>
                   Orígen
                 </Heading>
-                <Text
-                  as="sub"
-                  sx={{
-                    color: countTextColor + " !important",
-                    fontSize: "sm",
-                  }}
-                >
-                  ({origins.length})
-                </Text>
+                <Tag>{origins.length}</Tag>
                 <Spacer />
-                <Button
-                  variant="greenButton"
-                  onClick={() => handleAddNew("origin")}
-                  isLoading={loadingMetadata}
+                <Tooltip
+                  openDelay={500}
+                  hasArrow
+                  placement="top"
+                  label="Crear origen"
+                  aria-label="Create Origin"
                 >
-                  Agregar
-                </Button>
+                  <IconButton
+                    px={4}
+                    aria-label="Create Origin"
+                    icon={<FaPlus />}
+                    variant="greenButton"
+                    onClick={() => handleAddNew("origin")}
+                    isLoading={loadingMetadata}
+                  />
+                </Tooltip>
               </Flex>
             </CardHeader>
             <CardBody overflowY="auto" height="calc(100% - 60px)" px={2}>
@@ -738,15 +748,16 @@ const RecipeMetaPage: React.FC = () => {
             )}
           </ModalBody>
           <ModalFooter>
-            <Button variant="redButton" mr={3} onClick={onClose}>
-              Cancelar
-            </Button>
             <Button
+              mr={3}
               variant="greenButton"
               onClick={handleSave}
               isLoading={loadingSave}
             >
               Guardar
+            </Button>
+            <Button variant="redButton" onClick={onClose}>
+              Cancelar
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/src/features/recipe-book/pages/Update.tsx
+++ b/src/features/recipe-book/pages/Update.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useParams } from "react-router-dom";
+import { FaArrowsRotate } from "react-icons/fa6";
 import { useEffect } from "react";
 import {
   Box,
@@ -53,8 +54,8 @@ const UpdateRecipePage = () => {
         (formData.ingredients ?? []).map((ingredient) => ({
           id: parseInt(ingredient.id),
           quantity: parseFloat(ingredient.quantity),
-        }))
-      )
+        })),
+      ),
     );
     body.append(
       "steps",
@@ -65,8 +66,8 @@ const UpdateRecipePage = () => {
           .map((step: string, index: number) => ({
             number: index + 1,
             instruction: step,
-          }))
-      )
+          })),
+      ),
     );
 
     if (formData.thumbnailFile) {
@@ -77,7 +78,7 @@ const UpdateRecipePage = () => {
       await updateRecipe(
         HTTP_METHODS.PATCH,
         `${API_BASE_URL}/recipe/${id}`,
-        body
+        body,
       );
 
       toast({
@@ -95,7 +96,9 @@ const UpdateRecipePage = () => {
       toast({
         position: "top",
         title: "Error",
-        description: apiMessage ?? "Hubo un error al actualizar la receta. Inténtalo de nuevo.",
+        description:
+          apiMessage ??
+          "Hubo un error al actualizar la receta. Inténtalo de nuevo.",
         status: "error",
         duration: 3000,
         isClosable: true,
@@ -128,7 +131,8 @@ const UpdateRecipePage = () => {
       <Flex justify="space-between" align="center" mb={6}>
         <Heading size="lg">Editar Receta</Heading>
         <RecipeFormButtons
-          submitButtonText="Actualizar Receta"
+          submitIcon={<FaArrowsRotate />}
+          submitTooltip="Actualizar receta"
           cancelAction={handleCancel}
           isLoading={isUpdating}
         />

--- a/src/features/recipe-book/pages/View.tsx
+++ b/src/features/recipe-book/pages/View.tsx
@@ -8,9 +8,12 @@ import {
   GridItem,
   Heading,
   Text,
+  Tooltip,
   useColorModeValue,
   VStack,
 } from "@chakra-ui/react";
+
+import { FaArrowLeft } from "react-icons/fa6";
 
 import useAxios from "../../../shared/hooks/axiosFetch";
 
@@ -37,7 +40,7 @@ const ViewRecipePage = () => {
   const recipeTags = useRecipeTags(recipe!);
 
   const [checkedIngredients, setCheckedIngredients] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
 
   const toggleIngredient = (ingredientId: string) => {
@@ -70,6 +73,22 @@ const ViewRecipePage = () => {
 
   return (
     <Box>
+      <Flex justify="flex-end">
+        <Tooltip
+          openDelay={500}
+          label="Volver al recetario"
+          hasArrow
+          placement="top"
+        >
+          <Button
+            px={4}
+            onClick={() => navigate("/recipes")}
+            variant="redButton"
+          >
+            <FaArrowLeft />
+          </Button>
+        </Tooltip>
+      </Flex>
       <Grid templateColumns="repeat(2, 1fr)" gap={6}>
         <GridItem>
           <VStack align="stretch" spacing={4}>
@@ -111,16 +130,6 @@ const ViewRecipePage = () => {
           />
         </GridItem>
       </Grid>
-
-      <Flex justify="flex-end">
-        <Button
-          mt={6}
-          onClick={() => navigate("/recipes")}
-          variant="greenButton"
-        >
-          Volver
-        </Button>
-      </Flex>
     </Box>
   );
 };

--- a/src/shared/components/forms/RecipeForm/RecipeFormButtons.tsx
+++ b/src/shared/components/forms/RecipeForm/RecipeFormButtons.tsx
@@ -1,28 +1,40 @@
-import { Button, Flex } from "@chakra-ui/react";
+import { Button, Flex, Tooltip } from "@chakra-ui/react";
 import { RecipeFormButtonsProps } from "./types";
+import { FaArrowLeft } from "react-icons/fa6";
 
 const RecipeFormButtons = ({
-  submitButtonText = "Guardar",
+  submitIcon,
+  submitTooltip = "Guardar",
   cancelAction,
   isLoading = false,
   formId = "recipe-form",
 }: RecipeFormButtonsProps) => {
   return (
-    <Flex gap={6}>
-      {cancelAction && (
-        <Button onClick={cancelAction} variant="redButton">
-          Cancelar
+    <Flex gap={4}>
+      <Tooltip openDelay={500} label={submitTooltip} hasArrow placement="top">
+        <Button
+          px={4}
+          type="submit"
+          form={formId}
+          variant="greenButton"
+          isLoading={isLoading}
+          loadingText="Guardando..."
+        >
+          {submitIcon}
         </Button>
+      </Tooltip>
+      {cancelAction && (
+        <Tooltip
+          openDelay={500}
+          label="Volver al recetario"
+          hasArrow
+          placement="top"
+        >
+          <Button px={4} onClick={cancelAction} variant="redButton">
+            <FaArrowLeft />
+          </Button>
+        </Tooltip>
       )}
-      <Button
-        type="submit"
-        form={formId}
-        variant="greenButton"
-        isLoading={isLoading}
-        loadingText="Guardando..."
-      >
-        {submitButtonText}
-      </Button>
     </Flex>
   );
 };

--- a/src/shared/components/forms/RecipeForm/types.ts
+++ b/src/shared/components/forms/RecipeForm/types.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   UseFormRegister,
   FieldErrors,
@@ -52,7 +53,8 @@ export interface RecipeFormProps {
 }
 
 export interface RecipeFormButtonsProps {
-  submitButtonText?: string;
+  submitIcon?: React.ReactNode;
+  submitTooltip?: string;
   cancelAction?: () => void;
   isLoading?: boolean;
   formId?: string;

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Box,
+  Divider,
   Flex,
   HStack,
   Heading,
@@ -16,12 +17,12 @@ import {
   useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
-import { FiLogOut, FiUser } from "react-icons/fi";
 import ColorModeToggle from "../ui/ColorModeToggle/ColorModeToggle";
 import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../../features/auth/hooks/useAuth";
 import ProfileModal from "../../../features/auth/components/ProfileModal";
+import { FaArrowRightFromBracket, FaUser } from "react-icons/fa6";
 
 function Header() {
   const { user, isAuthenticated, logout } = useAuth();
@@ -66,44 +67,53 @@ function Header() {
         <HStack align="center" gap="16px" mr="4">
           <ColorModeToggle />
           {isAuthenticated && user && (
-            <Menu>
-              <MenuButton>
-                <Avatar
-                  src={user.avatar ?? undefined}
-                  name={user.username}
-                  backgroundColor="green.800"
-                  color="green.50"
-                  size="sm"
-                  cursor="pointer"
-                />
-              </MenuButton>
-              <MenuList>
-                <MenuItem
-                  isDisabled
-                  _disabled={{ opacity: 1, cursor: "default" }}
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text fontWeight="semibold" fontSize="sm">
-                      {user.username}
-                    </Text>
-                    <Text fontSize="xs" color="gray.400">
-                      {user.email}
-                    </Text>
-                  </VStack>
-                </MenuItem>
-                <MenuDivider />
-                <MenuItem icon={<FiUser />} onClick={onOpen}>
-                  Mi perfil
-                </MenuItem>
-                <MenuItem
-                  icon={<FiLogOut />}
-                  onClick={handleLogout}
-                  color="red.400"
-                >
-                  Cerrar sesión
-                </MenuItem>
-              </MenuList>
-            </Menu>
+            <>
+              <Divider
+                borderColor={useColorModeValue("green.700", "green.400")}
+                orientation="vertical"
+                height="32px"
+              />
+              <Menu>
+                <MenuButton>
+                  <Avatar
+                    src={user.avatar ?? undefined}
+                    name={user.username}
+                    backgroundColor="green.800"
+                    color="green.50"
+                    size="md"
+                    cursor="pointer"
+                  />
+                </MenuButton>
+                <MenuList>
+                  <MenuItem
+                    isDisabled
+                    _disabled={{ opacity: 1, cursor: "default" }}
+                  >
+                    <VStack align="start" spacing={0}>
+                      <Text fontWeight="semibold" fontSize="sm">
+                        {user.username}
+                      </Text>
+                      <Text fontSize="xs" color="gray.400">
+                        {user.email}
+                      </Text>
+                    </VStack>
+                  </MenuItem>
+                  <MenuDivider
+                    borderColor={useColorModeValue("gray.300", "gray.500")}
+                  />
+                  <MenuItem icon={<FaUser />} onClick={onOpen}>
+                    Mi perfil
+                  </MenuItem>
+                  <MenuItem
+                    icon={<FaArrowRightFromBracket />}
+                    onClick={handleLogout}
+                    color="red.400"
+                  >
+                    Cerrar sesión
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+            </>
           )}
         </HStack>
       </Flex>

--- a/src/shared/components/layout/SideNav.tsx
+++ b/src/shared/components/layout/SideNav.tsx
@@ -27,7 +27,7 @@ function SideNav({}: Props) {
   const [selectedFeature, setSelectedFeature] = useState<Feature>(() => {
     const currentPath = location.pathname;
     const matchingRoute = parseRoutes.find((route) =>
-      currentPath.startsWith(`/${route.route}`)
+      currentPath.startsWith(`/${route.route}`),
     );
     return matchingRoute ? { id: 1, name: matchingRoute.name } : defaultFeature;
   });
@@ -60,7 +60,7 @@ function SideNav({}: Props) {
       </Heading>
       <Divider
         my={4}
-        borderColor={useColorModeValue("green.600", "green.600")}
+        borderColor={useColorModeValue("green.700", "green.400")}
       />
 
       {loadingFeatures ? (

--- a/src/shared/components/ui/ColorModeToggle/ColorModeToggle.tsx
+++ b/src/shared/components/ui/ColorModeToggle/ColorModeToggle.tsx
@@ -1,5 +1,10 @@
-import { IconButton, IconButtonProps, useColorMode } from "@chakra-ui/react";
-import { FaMoon, FaSun } from "react-icons/fa";
+import {
+  IconButton,
+  IconButtonProps,
+  Tooltip,
+  useColorMode,
+} from "@chakra-ui/react";
+import { FaMoon, FaSun } from "react-icons/fa6";
 
 type Props = Omit<IconButtonProps, "aria-label" | "icon" | "onClick">;
 
@@ -7,13 +12,23 @@ function ColorModeToggle(props: Props) {
   const { colorMode, toggleColorMode } = useColorMode();
 
   return (
-    <IconButton
-      aria-label="Cambiar tema"
-      icon={colorMode === "light" ? <FaMoon /> : <FaSun />}
-      onClick={toggleColorMode}
-      variant="themeToggle"
-      {...props}
-    />
+    <Tooltip
+      openDelay={500}
+      label={
+        colorMode === "light" ? "Cambiar a tema oscuro" : "Cambiar a tema claro"
+      }
+      hasArrow
+      placement="top"
+    >
+      <IconButton
+        px={4}
+        aria-label="Cambiar tema"
+        icon={colorMode === "light" ? <FaMoon /> : <FaSun />}
+        onClick={toggleColorMode}
+        variant="themeToggle"
+        {...props}
+      />
+    </Tooltip>
   );
 }
 

--- a/src/shared/components/ui/ImageUpload/ImageUpload.tsx
+++ b/src/shared/components/ui/ImageUpload/ImageUpload.tsx
@@ -10,7 +10,7 @@ import {
   VStack,
   useColorModeValue,
 } from "@chakra-ui/react";
-import { FaImage, FaTrash, FaUndo, FaUpload } from "react-icons/fa";
+import { FaImage, FaTrash, FaRotateLeft, FaUpload } from "react-icons/fa6";
 
 import { ImageUploadProps } from "./types";
 
@@ -121,7 +121,7 @@ const ImageUpload = ({
             {showUndo && (
               <Button
                 size="sm"
-                leftIcon={<Icon as={FaUndo} />}
+                leftIcon={<Icon as={FaRotateLeft} />}
                 onClick={handleUndo}
                 colorScheme="red"
                 variant="solid"
@@ -169,7 +169,7 @@ const ImageUpload = ({
           {isCleared && existingUrl && (
             <Button
               size="sm"
-              leftIcon={<Icon as={FaUndo} />}
+              leftIcon={<Icon as={FaRotateLeft} />}
               onClick={() => setIsCleared(false)}
               colorScheme="gray"
               variant="outline"

--- a/src/shared/components/ui/RecipeImage/RecipeImage.tsx
+++ b/src/shared/components/ui/RecipeImage/RecipeImage.tsx
@@ -8,7 +8,7 @@ import {
   useColorModeValue,
   VStack,
 } from "@chakra-ui/react";
-import { FaImage, FaExclamationTriangle } from "react-icons/fa";
+import { FaImage, FaTriangleExclamation } from "react-icons/fa6";
 
 import { RecipeImageProps } from "./types";
 
@@ -70,7 +70,7 @@ const RecipeImage = ({
     >
       <VStack spacing={2}>
         <Icon
-          as={hasError ? FaExclamationTriangle : FaImage}
+          as={hasError ? FaTriangleExclamation : FaImage}
           boxSize={8}
           color={hasError ? "red.400" : fallbackColor}
         />

--- a/src/shared/components/ui/RecipeTables/IngredientsTable.tsx
+++ b/src/shared/components/ui/RecipeTables/IngredientsTable.tsx
@@ -9,7 +9,7 @@ import {
   Checkbox,
   HStack,
 } from "@chakra-ui/react";
-import { FaCheckSquare } from "react-icons/fa";
+import { FaSquareCheck } from "react-icons/fa6";
 
 import { IngredientsTableProps } from "./types";
 
@@ -31,7 +31,7 @@ const IngredientsTable = ({
             {interactive && (
               <Th width={12}>
                 <HStack justify="center">
-                  <FaCheckSquare />
+                  <FaSquareCheck />
                 </HStack>
               </Th>
             )}

--- a/src/shared/components/ui/RecipeTables/StepsTable.tsx
+++ b/src/shared/components/ui/RecipeTables/StepsTable.tsx
@@ -9,7 +9,7 @@ import {
   Checkbox,
   HStack,
 } from "@chakra-ui/react";
-import { FaCheckSquare } from "react-icons/fa";
+import { FaSquareCheck } from "react-icons/fa6";
 
 import { StepsTableProps } from "./types";
 
@@ -31,7 +31,7 @@ const StepsTable = ({
             {interactive && (
               <Th width={12}>
                 <HStack justify="center">
-                  <FaCheckSquare />
+                  <FaSquareCheck />
                 </HStack>
               </Th>
             )}

--- a/src/shared/components/ui/RecipeTags/useRecipeTags.ts
+++ b/src/shared/components/ui/RecipeTags/useRecipeTags.ts
@@ -1,10 +1,10 @@
 import {
   FaStar,
   FaUtensils,
-  FaGlobeAmericas,
+  FaEarthAmericas,
   FaClock,
   FaUsers,
-} from "react-icons/fa";
+} from "react-icons/fa6";
 import { TagData } from "./types";
 import { Recipe } from "../../../../features/recipe-book/types";
 import { setTimeText } from "../../../../features/recipe-book/utils/setTimeText";
@@ -30,7 +30,7 @@ export const useRecipeTags = (recipe: Recipe): TagData[] => {
     },
     {
       label: recipe.origin?.name || "Sin origen",
-      icon: FaGlobeAmericas,
+      icon: FaEarthAmericas,
       colorScheme: "gray",
       iconSize: "16px",
     },

--- a/src/shared/themes/heading.ts
+++ b/src/shared/themes/heading.ts
@@ -1,8 +1,8 @@
 const HeadingTheme = {
   baseStyle: {
-    color: "green.900",
+    color: "gray.800",
     _dark: {
-      color: "green.100",
+      color: "gray.200",
     },
   },
 };

--- a/src/shared/themes/link.ts
+++ b/src/shared/themes/link.ts
@@ -22,6 +22,22 @@ const LinkTheme = {
         fontWeight: "bold",
       },
     },
+    loginFlow: {
+      color: "green.400",
+      fontSize: "sm",
+      fontWeight: "bold",
+      _hover: {
+        textDecoration: "underline",
+      },
+      _dark: {
+        color: "green.400",
+        fontSize: "sm",
+        fontWeight: "bold",
+        _hover: {
+          textDecoration: "underline",
+        },
+      },
+    },
   },
 };
 

--- a/src/shared/themes/link.ts
+++ b/src/shared/themes/link.ts
@@ -1,11 +1,11 @@
 const LinkTheme = {
   baseStyle: {
-    color: "green.700",
+    color: "gray.800",
     _hover: {
       textDecoration: "none",
     },
     _dark: {
-      color: "green.200",
+      color: "gray.200",
       _hover: {
         textDecoration: "none",
       },

--- a/src/shared/themes/modal.ts
+++ b/src/shared/themes/modal.ts
@@ -1,10 +1,10 @@
 const ModalTheme = {
   baseStyle: {
     header: {
-      color: "green.900",
+      color: "gray.800",
       _dark: {
-        color: "green.100"
-      }
+        color: "gray.200",
+      },
     },
     dialog: {
       background: "gray.50",
@@ -19,6 +19,6 @@ const ModalTheme = {
       },
     },
   },
-}
+};
 
 export default ModalTheme;

--- a/src/shared/themes/text.ts
+++ b/src/shared/themes/text.ts
@@ -1,8 +1,8 @@
 const TextTheme = {
   baseStyle: {
-    color: "green.800",
+    color: "gray.800",
     _dark: {
-      color: "green.200",
+      color: "gray.200",
     },
   },
   variants: {


### PR DESCRIPTION
### 📋 Resumen

Mejoras visuales y micro-interacciones a lo largo de la aplicación: migración de iconos a `react-icons v6`, tooltips en todos los botones de acción, conversión de botones con texto a botones de solo icono, apertura de cards con un solo click, columna de `usos` en la tabla de `Meta` y refactor del formulario de receta para soportar iconos dinámicos.

---

### Cambios incluidos:

- **Migración `fa` → `fa6`**: Reemplazo de todos los iconos de `react-icons/fa` a `react-icons/fa6` con los nombres actualizados (`FaGear`, `FaPenToSquare`, `FaSquareCheck`, `FaEarthAmericas`, `FaTriangleExclamation`, `FaRotateLeft`, `FaArrowDownAZ`, `FaArrowDownZA`, `FaMagnifyingGlass`, `FaArrowLeft`, `FaXmark`)
- **Tooltips**: Agregados en todos los botones de icono con `openDelay={500}`, `hasArrow` y `placement="top"` — modal de receta, búsqueda/filtros, botones de acción, cambio de tema, botón de volver y botones del formulario
- **Botones de solo icono**: `ActionButtons` y `RecipeFormButtons` convertidos de texto a icono; `RecipeFormButtons` ahora acepta `submitIcon` y `submitTooltip` como props en lugar de `submitButtonText`
- **Apertura de card con un click**: Cambiado `onDoubleClick` → `onClick` en `RecipeGrid`
- **Tabla Meta — columna Usos**: Agregada columna `usageCount`; `tableLayout: fixed` para prevenir scroll horizontal; nombre truncado con ellipsis
- **Fix de focus en modal**: Span oculto con `initialFocusRef` para evitar que el tooltip del primer botón se muestre al abrir el modal
- **Tooltip en SearchFilters**: Envuelto el icono de búsqueda en `<Box display="flex">` para que Chakra pueda anclar correctamente el tooltip
- **Divider en Header**: Separador vertical entre el toggle de tema y el avatar del usuario
- **Colores del tema**: Ajustes de color en `ProfileModal` (Divider verde) y corrección del color del `ModalHeader` modificando `modal.ts` del tema

---

### 🧩 Tipo de cambio

- [ ] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [x] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #73

---

### 🗒️ Notas adicionales

El botón de duplicar receta está temporalmente deshabilitado (`isDisabled={true}`) — el endpoint fue perdido en un merge incorrecto al backend. El refactor (navegar directo a `/recipes/create` con los datos pre-cargados) queda pendiente para una PR separada.
